### PR TITLE
Fixes after review

### DIFF
--- a/inngest-durable-functions/SKILL.md
+++ b/inngest-durable-functions/SKILL.md
@@ -315,7 +315,7 @@ const processUser = inngest.createFunction(
 ### **Custom Retry Timing**
 
 ```typescript
-import { Inngest, RetryAfterError } from "inngest";
+import { RetryAfterError } from "inngest";
 
 const respectRateLimit = inngest.createFunction(
   { id: "api-call" },

--- a/inngest-durable-functions/SKILL.md
+++ b/inngest-durable-functions/SKILL.md
@@ -231,7 +231,7 @@ const processWithTimeout = inngest.createFunction(
     id: "process-with-timeout",
     timeouts: {
       start: "5m", // Cancel if not started within 5 minutes
-      run: "30m" // Cancel if running longer than 30 minutes
+      finish: "30m" // Cancel if not finished within 30 minutes
     }
   },
   { event: "long/process.requested" },
@@ -276,9 +276,10 @@ const reliableFunction = inngest.createFunction(
   },
   { event: "critical/task" },
   async ({ event, step, attempt }) => {
-    // Access attempt number (0-indexed)
+    // `attempt` is the function-level attempt counter (0-indexed)
+    // It tracks retries for the currently executing step, not the overall function
     if (attempt > 5) {
-      // Different logic for later attempts
+      // Different logic for later attempts of the current step
     }
   }
 );
@@ -314,7 +315,7 @@ const processUser = inngest.createFunction(
 ### **Custom Retry Timing**
 
 ```typescript
-import { RetryAfterError } from "inngest";
+import { Inngest, RetryAfterError } from "inngest";
 
 const respectRateLimit = inngest.createFunction(
   { id: "api-call" },
@@ -388,7 +389,7 @@ const realTimeFunction = inngest.createFunction(
   {
     id: "real-time-function",
     checkpointing: {
-      maxRuntime: "300s", // Max continuous execution time
+      maxRuntime: "5m", // Max continuous execution time
       bufferedSteps: 2, // Buffer 2 steps before checkpointing
       maxInterval: "10s" // Max wait before checkpoint
     }

--- a/inngest-durable-functions/references/error-handling.md
+++ b/inngest-durable-functions/references/error-handling.md
@@ -106,25 +106,17 @@ const smartErrorHandling = inngest.createFunction(
 
       if (!user) {
         // Don't retry - user doesn't exist
-        throw new NonRetriableError("User not found", {
-          userId: event.data.userId
-        });
+        throw new NonRetriableError("User not found");
       }
 
       if (user.status === "deleted") {
         // Don't retry - user is deleted
-        throw new NonRetriableError("User account deleted", {
-          userId: user.id,
-          deletedAt: user.deletedAt
-        });
+        throw new NonRetriableError("User account deleted");
       }
 
       if (!user.hasPermission("process")) {
         // Don't retry - insufficient permissions
-        throw new NonRetriableError("User lacks required permissions", {
-          userId: user.id,
-          requiredPermission: "process"
-        });
+        throw new NonRetriableError("User lacks required permissions");
       }
 
       return user;
@@ -306,8 +298,11 @@ const processWithFailureHandler = inngest.createFunction(
   {
     id: "process-with-failure-handler",
     retries: 3,
-    onFailure: async ({ event, error, runId }) => {
+    onFailure: async ({ event, error }) => {
       // This runs when function fails after all retries
+      // Access run_id from the failure event data
+      const runId = event.data.run_id;
+
       console.error("Function failed:", {
         eventName: event.name,
         runId,
@@ -345,9 +340,8 @@ const processWithFailureHandler = inngest.createFunction(
 const structuredErrorLogging = inngest.createFunction(
   { id: "structured-error-logging" },
   { event: "process/with-logging" },
-  async ({ event, step, logger, runId }) => {
+  async ({ event, step, logger }) => {
     const baseContext = {
-      runId,
       eventName: event.name,
       eventId: event.id,
       userId: event.data.userId

--- a/inngest-flow-control/SKILL.md
+++ b/inngest-flow-control/SKILL.md
@@ -279,6 +279,8 @@ inngest.createFunction(
     batchEvents: {
       maxSize: 100, // Up to 100 events
       timeout: "30s", // Or 30 seconds, whichever first
+      // `key` groups events into separate batches per unique value
+      // This is different from expressions `if` which filters events
       key: "event.data.campaign_id" // Batch per campaign
     }
   },

--- a/inngest-middleware/SKILL.md
+++ b/inngest-middleware/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inngest-middleware
-description: Create and use Inngest middleware for cross-cutting concerns. Covers the middleware lifecycle, creating custom middleware, dependency injection with the built-in dependencyInjectionMiddleware, and custom middleware patterns for encryption and error tracking.
+description: Create and use Inngest middleware for cross-cutting concerns. Covers the middleware lifecycle, creating custom middleware, dependency injection with dependencyInjectionMiddleware, encryption via @inngest/middleware-encryption, Sentry error tracking via @inngest/middleware-sentry, and custom middleware patterns.
 ---
 
 # Inngest Middleware
@@ -162,11 +162,50 @@ inngest.createFunction(
 );
 ````
 
-## Built-in Middleware
+## Middleware Packages
 
-Inngest provides `dependencyInjectionMiddleware` as a built-in export (shown above). For encryption or error tracking, **create custom middleware** using the `InngestMiddleware` class. **See [Built-in Middleware Reference](./references/built-in-middleware.md) for complete custom implementations of encryption and Sentry error tracking middleware.**
+Beyond `dependencyInjectionMiddleware` (built-in, shown above), Inngest provides official middleware as **separate packages**. **See [Middleware Reference](./references/built-in-middleware.md) for complete details.**
 
-> **Note:** There are no built-in `encryptionMiddleware` or `sentryMiddleware` exports from the `inngest` package. Use the custom middleware patterns shown in the reference docs.
+### Encryption Middleware
+
+```bash
+npm install @inngest/middleware-encryption
+```
+
+```typescript
+import { encryptionMiddleware } from "@inngest/middleware-encryption";
+
+const inngest = new Inngest({
+  id: "my-app",
+  middleware: [
+    encryptionMiddleware({
+      key: process.env.ENCRYPTION_KEY,
+    })
+  ]
+});
+```
+
+Automatically encrypts all step data, function output, and event `data.encrypted` field. Supports key rotation via `fallbackDecryptionKeys`.
+
+### Sentry Error Tracking
+
+```bash
+npm install @inngest/middleware-sentry
+```
+
+```typescript
+import * as Sentry from "@sentry/node";
+import { sentryMiddleware } from "@inngest/middleware-sentry";
+
+Sentry.init({ /* your Sentry config */ });
+
+const inngest = new Inngest({
+  id: "my-app",
+  middleware: [sentryMiddleware()]
+});
+```
+
+Captures exceptions, adds tracing to each function run, and includes function ID and event names as context. Requires `@sentry/*@>=8.0.0`.
 
 ## Common Middleware Patterns
 

--- a/inngest-middleware/SKILL.md
+++ b/inngest-middleware/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inngest-middleware
-description: Create and use Inngest middleware for cross-cutting concerns. Covers the middleware lifecycle, creating custom middleware, dependency injection, and built-in middleware for encryption and error tracking.
+description: Create and use Inngest middleware for cross-cutting concerns. Covers the middleware lifecycle, creating custom middleware, dependency injection with the built-in dependencyInjectionMiddleware, and custom middleware patterns for encryption and error tracking.
 ---
 
 # Inngest Middleware
@@ -68,6 +68,7 @@ const loggingMiddleware = new InngestMiddleware({
 
     return {
       // Function execution lifecycle
+      // Note: `fn` is loosely typed in middleware generics; fn.id works at runtime
       onFunctionRun({ ctx, fn }) {
         return {
           beforeExecution() {
@@ -107,8 +108,8 @@ const loggingMiddleware = new InngestMiddleware({
               events: payloads.map((p) => p.name)
             });
 
-            // Return unmodified payloads
-            return { payloads };
+            // Spread to convert readonly array to mutable array
+            return { payloads: [...payloads] };
           }
         };
       }
@@ -163,39 +164,9 @@ inngest.createFunction(
 
 ## Built-in Middleware
 
-Inngest provides pre-built middleware for common use cases. **See [Built-in Middleware Reference](./references/built-in-middleware.md) for complete implementation details.**
+Inngest provides `dependencyInjectionMiddleware` as a built-in export (shown above). For encryption or error tracking, **create custom middleware** using the `InngestMiddleware` class. **See [Built-in Middleware Reference](./references/built-in-middleware.md) for complete custom implementations of encryption and Sentry error tracking middleware.**
 
-### Encryption Middleware
-
-```typescript
-import { encryptionMiddleware } from "inngest";
-
-const inngest = new Inngest({
-  id: "my-app",
-  middleware: [
-    encryptionMiddleware({
-      key: process.env.ENCRYPTION_KEY
-      // Automatically encrypt/decrypt sensitive data
-    })
-  ]
-});
-```
-
-### Sentry Error Tracking
-
-```typescript
-import { sentryMiddleware } from "inngest";
-
-const inngest = new Inngest({
-  id: "my-app",
-  middleware: [
-    sentryMiddleware({
-      dsn: process.env.SENTRY_DSN
-      // Auto-capture errors and performance data
-    })
-  ]
-});
-```
+> **Note:** There are no built-in `encryptionMiddleware` or `sentryMiddleware` exports from the `inngest` package. Use the custom middleware patterns shown in the reference docs.
 
 ## Common Middleware Patterns
 

--- a/inngest-steps/SKILL.md
+++ b/inngest-steps/SKILL.md
@@ -160,7 +160,8 @@ const taskId = "task-" + crypto.randomUUID();
 
 const signal = await step.waitForSignal("wait-for-task-completion", {
   signal: taskId,
-  timeout: "1h"
+  timeout: "1h",
+  onConflict: "replace" // Required: "replace" overwrites pending signal, "fail" throws an error
 });
 
 // Send signal elsewhere via Inngest API or SDK


### PR DESCRIPTION
Various fixes after additional review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Inngest docs to fix examples, clarify middleware package exports, and expand setup with typed events, logger, and server notes. Highlights: correct timeout keys, clearer retry semantics, default encryption behavior, Sentry requirements, and Express body size guidance.

- **Bug Fixes**
  - Durable functions: rename timeout "run" to "finish"; clarify that `attempt` counts retries for the current step; use "5m" for checkpointing `maxRuntime`.
  - Error handling: simplify `NonRetriableError` examples (no extra metadata); read `run_id` from `event.data` in `onFailure`; remove `runId` from logging context.
  - Middleware: only `dependencyInjectionMiddleware` is built-in; encryption and Sentry are separate packages with install commands and updated imports; document default encryption targets (step data, outputs, `event.data.encrypted`) and key rotation; Sentry requires `@sentry/*@>=8.0.0` and adds tracing; clarify `fn` typing and return payloads via spread.
  - Flow control and steps: explain `batchEvents.key` vs filter expressions; require `onConflict` in `waitForSignal`.
  - Setup: add `EventSchemas` typed events example; document `logger` and `middleware` options; note `express.json({ limit: "10mb" })`; add note that `inngest/connect` requires SDK v3.27+.

- **Migration**
  - Update any functions using timeouts: replace "run" with "finish".
  - For Express apps, use `express.json({ limit: "10mb" })` to support larger function state.
  - Install and import middleware from `@inngest/middleware-encryption` and `@inngest/middleware-sentry`; keep `dependencyInjectionMiddleware` from `"inngest"`.

<sup>Written for commit 2732e09200a9e3ca7c90a98504b79c94db50a10c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

