### PR TITLE
Update major breaking changes for v4 SDK

### DIFF
--- a/skills/inngest-durable-functions/SKILL.md
+++ b/skills/inngest-durable-functions/SKILL.md
@@ -370,7 +370,17 @@ const inngest = new Inngest({
   id: "my-app",
   logger // Pass logger to client
 });
+
+// Or use the built-in ConsoleLogger for simple log level control
+import { ConsoleLogger, Inngest } from "inngest";
+
+const inngest = new Inngest({
+  id: "my-app",
+  logger: new ConsoleLogger({ level: "debug" }) // "debug" | "info" | "warn" | "error"
+});
 ```
+
+**⚠️ v4 Breaking Change:** The `logLevel` option has been removed. Use the `logger` option with `ConsoleLogger` or a custom logger instead.
 
 ### **Function Logging Patterns**
 

--- a/skills/inngest-durable-functions/SKILL.md
+++ b/skills/inngest-durable-functions/SKILL.md
@@ -75,10 +75,10 @@ If you're hitting these limits, break your function into smaller functions conne
 const processOrder = inngest.createFunction(
   {
     id: "process-order", // Unique, never change this
+    triggers: [{ event: "order/created" }],
     retries: 4, // Default: 4 retries per step
     concurrency: 10 // Max concurrent executions
   },
-  { event: "order/created" }, // Trigger
   async ({ event, step }) => {
     // Your durable workflow
   }
@@ -102,42 +102,61 @@ await step.run("send-confirmation", () => sendEmail(event.data.email));
 
 ### **Event Triggers**
 
+Triggers are defined in the `triggers` array in the first argument of `createFunction`:
+
 ```typescript
 // Single event trigger
-{ event: "user/signup" }
+inngest.createFunction(
+  { id: "my-fn", triggers: [{ event: "user/signup" }] },
+  async ({ event }) => { /* ... */ }
+);
 
 // Event with conditional filter
-{
-  event: "user/action",
-  if: 'event.data.action == "purchase" && event.data.amount > 100'
-}
+inngest.createFunction(
+  { id: "my-fn", triggers: [{ event: "user/action", if: 'event.data.action == "purchase" && event.data.amount > 100' }] },
+  async ({ event }) => { /* ... */ }
+);
 
 // Multiple triggers (up to 10)
-[
-  { event: "user/signup" },
-  { event: "user/login", if: 'event.data.firstLogin == true' },
-  { cron: "0 9 * * *" } // Daily at 9 AM
-]
+inngest.createFunction(
+  {
+    id: "my-fn",
+    triggers: [
+      { event: "user/signup" },
+      { event: "user/login", if: 'event.data.firstLogin == true' },
+      { cron: "0 9 * * *" } // Daily at 9 AM
+    ]
+  },
+  async ({ event }) => { /* ... */ }
+);
 ```
 
 ### **Cron Triggers**
 
 ```typescript
 // Basic cron
-{
-  cron: "0 */6 * * *";
-} // Every 6 hours
+inngest.createFunction(
+  { id: "my-fn", triggers: [{ cron: "0 */6 * * *" }] }, // Every 6 hours
+  async ({ step }) => { /* ... */ }
+);
 
 // With timezone
-{
-  cron: "TZ=Europe/Paris 0 12 * * 5";
-} // Fridays at noon Paris time
+inngest.createFunction(
+  { id: "my-fn", triggers: [{ cron: "TZ=Europe/Paris 0 12 * * 5" }] }, // Fridays at noon Paris time
+  async ({ step }) => { /* ... */ }
+);
 
 // Combine with events
-[
-  { event: "manual/report.requested" },
-  { cron: "0 0 * * 0" } // Weekly on Sunday
-];
+inngest.createFunction(
+  {
+    id: "my-fn",
+    triggers: [
+      { event: "manual/report.requested" },
+      { cron: "0 0 * * 0" } // Weekly on Sunday
+    ]
+  },
+  async ({ event, step }) => { /* ... */ }
+);
 ```
 
 ### **Function Invocation**
@@ -174,10 +193,10 @@ await inngest.send({
 const sendEmail = inngest.createFunction(
   {
     id: "send-checkout-email",
+    triggers: [{ event: "cart/checkout.completed" }],
     // Only run once per cartId per 24 hours
     idempotency: "event.data.cartId"
   },
-  { event: "cart/checkout.completed" },
   async ({ event, step }) => {
     // This function won't run twice for same cartId
   }
@@ -187,10 +206,10 @@ const sendEmail = inngest.createFunction(
 const processUserAction = inngest.createFunction(
   {
     id: "process-user-action",
+    triggers: [{ event: "user/action.performed" }],
     // Unique per user + organization combination
     idempotency: 'event.data.userId + "-" + event.data.organizationId'
   },
-  { event: "user/action.performed" },
   async ({ event, step }) => {
     /* ... */
   }
@@ -207,6 +226,7 @@ In expressions, `event` = the **original** triggering event, `async` = the **new
 const processOrder = inngest.createFunction(
   {
     id: "process-order",
+    triggers: [{ event: "order/created" }],
     cancelOn: [
       {
         event: "order/cancelled",
@@ -214,7 +234,6 @@ const processOrder = inngest.createFunction(
       }
     ]
   },
-  { event: "order/created" },
   async ({ event, step }) => {
     await step.sleepUntil("wait-for-payment", event.data.paymentDue);
     // Will be cancelled if order/cancelled event received
@@ -229,12 +248,12 @@ const processOrder = inngest.createFunction(
 const processWithTimeout = inngest.createFunction(
   {
     id: "process-with-timeout",
+    triggers: [{ event: "long/process.requested" }],
     timeouts: {
       start: "5m", // Cancel if not started within 5 minutes
       finish: "30m" // Cancel if not finished within 30 minutes
     }
   },
-  { event: "long/process.requested" },
   async ({ event, step }) => {
     /* ... */
   }
@@ -246,8 +265,7 @@ const processWithTimeout = inngest.createFunction(
 ```typescript
 // Listen for cancellation events
 const cleanupCancelled = inngest.createFunction(
-  { id: "cleanup-cancelled-process" },
-  { event: "inngest/function.cancelled" },
+  { id: "cleanup-cancelled-process", triggers: [{ event: "inngest/function.cancelled" }] },
   async ({ event, step }) => {
     if (event.data.function_id === "process-order") {
       await step.run("cleanup-resources", () => {
@@ -272,9 +290,9 @@ const cleanupCancelled = inngest.createFunction(
 const reliableFunction = inngest.createFunction(
   {
     id: "reliable-function",
+    triggers: [{ event: "critical/task" }],
     retries: 10 // Up to 10 retries per step
   },
-  { event: "critical/task" },
   async ({ event, step, attempt }) => {
     // `attempt` is the function-level attempt counter (0-indexed)
     // It tracks retries for the currently executing step, not the overall function
@@ -293,8 +311,7 @@ Prevent retries for code that won't succeed upon retry.
 import { NonRetriableError } from "inngest";
 
 const processUser = inngest.createFunction(
-  { id: "process-user" },
-  { event: "user/process.requested" },
+  { id: "process-user", triggers: [{ event: "user/process.requested" }] },
   async ({ event, step }) => {
     const user = await step.run("fetch-user", async () => {
       const user = await db.users.findOne(event.data.userId);
@@ -318,8 +335,7 @@ const processUser = inngest.createFunction(
 import { RetryAfterError } from "inngest";
 
 const respectRateLimit = inngest.createFunction(
-  { id: "api-call" },
-  { event: "api/call.requested" },
+  { id: "api-call", triggers: [{ event: "api/call.requested" }] },
   async ({ event, step }) => {
     await step.run("call-api", async () => {
       const response = await externalAPI.call(event.data);
@@ -360,8 +376,7 @@ const inngest = new Inngest({
 
 ```typescript
 const processData = inngest.createFunction(
-  { id: "process-data" },
-  { event: "data/process.requested" },
+  { id: "process-data", triggers: [{ event: "data/process.requested" }] },
   async ({ event, step, logger }) => {
     // ✅ GOOD: Log inside steps to avoid duplicates
     const result = await step.run("fetch-data", async () => {
@@ -383,24 +398,35 @@ const processData = inngest.createFunction(
 
 ### **Checkpointing**
 
+Checkpointing is **enabled by default in v4**. It allows functions to persist state periodically during execution, reducing latency between steps.
+
 ```typescript
-// Enable checkpointing for lower latency
+// Checkpointing is enabled by default in v4
+// Configure maxRuntime for serverless platforms (set to 60-80% of platform timeout)
 const realTimeFunction = inngest.createFunction(
   {
     id: "real-time-function",
+    triggers: [{ event: "realtime/process" }],
     checkpointing: {
-      maxRuntime: "5m", // Max continuous execution time
-      bufferedSteps: 2, // Buffer 2 steps before checkpointing
-      maxInterval: "10s" // Max wait before checkpoint
+      maxRuntime: "50s", // For serverless with 60s timeout
     }
   },
-  { event: "realtime/process" },
   async ({ event, step }) => {
     // Steps execute immediately with periodic checkpointing
     const result1 = await step.run("step-1", () => process1(event.data));
     const result2 = await step.run("step-2", () => process2(result1));
     return { result2 };
   }
+);
+
+// Disable checkpointing if needed
+const legacyFunction = inngest.createFunction(
+  {
+    id: "legacy-function",
+    triggers: [{ event: "legacy/process" }],
+    checkpointing: false
+  },
+  async ({ event, step }) => { /* ... */ }
 );
 ```
 
@@ -410,8 +436,7 @@ const realTimeFunction = inngest.createFunction(
 
 ```typescript
 const conditionalProcess = inngest.createFunction(
-  { id: "conditional-process" },
-  { event: "process/conditional" },
+  { id: "conditional-process", triggers: [{ event: "process/conditional" }] },
   async ({ event, step }) => {
     const userData = await step.run("fetch-user", () => {
       return getUserData(event.data.userId);
@@ -436,8 +461,7 @@ const conditionalProcess = inngest.createFunction(
 
 ```typescript
 const robustProcess = inngest.createFunction(
-  { id: "robust-process" },
-  { event: "process/robust" },
+  { id: "robust-process", triggers: [{ event: "process/robust" }] },
   async ({ event, step }) => {
     let primaryResult;
 

--- a/skills/inngest-durable-functions/references/checkpointing.md
+++ b/skills/inngest-durable-functions/references/checkpointing.md
@@ -14,8 +14,7 @@ Checkpointing executes steps **immediately on your server** rather than waiting 
 ```typescript
 // Traditional execution: Each step = separate HTTP request
 const traditional = inngest.createFunction(
-  { id: "traditional-execution" },
-  { event: "process/traditional" },
+  { id: "traditional-execution", triggers: [{ event: "process/traditional" }] },
   async ({ event, step }) => {
     // Step 1: HTTP request to Inngest → response → continue
     const data = await step.run("fetch-data", () => fetchData());
@@ -32,9 +31,8 @@ const traditional = inngest.createFunction(
 const checkpointed = inngest.createFunction(
   {
     id: "checkpointed-execution",
-    checkpointing: true // Enable checkpointing
+    triggers: [{ event: "process/checkpointed" }]
   },
-  { event: "process/checkpointed" },
   async ({ event, step }) => {
     // All steps run immediately, checkpoints sent periodically
     const data = await step.run("fetch-data", () => fetchData());
@@ -46,24 +44,24 @@ const checkpointed = inngest.createFunction(
 
 ## Basic Checkpointing Setup
 
+**Checkpointing is enabled by default in v4.** All functions automatically use checkpointing for optimal performance. You can configure `maxRuntime` for serverless environments or disable it per-function if needed.
+
 ### TypeScript Configuration
 
 ```typescript
 import { Inngest } from "inngest";
 
-// Enable checkpointing globally for all functions
+// Checkpointing is enabled by default - no configuration needed
 export const inngest = new Inngest({
-  id: "my-app",
-  checkpointing: true
+  id: "my-app"
 });
 
-// Or enable per-function
+// Functions automatically use checkpointing
 const realTimeFunction = inngest.createFunction(
   {
     id: "real-time-function",
-    checkpointing: true
+    triggers: [{ event: "realtime/process" }]
   },
-  { event: "realtime/process" },
   async ({ event, step }) => {
     // Steps execute immediately with periodic checkpointing
     const result1 = await step.run("immediate-step-1", () =>
@@ -73,6 +71,36 @@ const realTimeFunction = inngest.createFunction(
     const result3 = await step.run("immediate-step-3", () => process3(result2));
 
     return { result: result3 };
+  }
+);
+
+// Configure maxRuntime for serverless environments
+const serverlessFunction = inngest.createFunction(
+  {
+    id: "serverless-function",
+    triggers: [{ event: "realtime/serverless" }],
+    checkpointing: {
+      maxRuntime: "4m45s" // Leave buffer before platform timeout
+    }
+  },
+  async ({ event, step }) => {
+    // Steps execute immediately with checkpointing
+    const result = await step.run("process", () => process(event.data));
+    return { result };
+  }
+);
+
+// Disable checkpointing for a specific function if needed
+const noCheckpointFunction = inngest.createFunction(
+  {
+    id: "no-checkpoint-function",
+    triggers: [{ event: "legacy/process" }],
+    checkpointing: false
+  },
+  async ({ event, step }) => {
+    // Uses traditional step-by-step orchestration
+    const result = await step.run("process", () => process(event.data));
+    return { result };
   }
 );
 ```
@@ -108,6 +136,7 @@ _, err := inngestgo.CreateFunction(
 const advancedCheckpointing = inngest.createFunction(
   {
     id: "advanced-checkpointing",
+    triggers: [{ event: "process/advanced" }],
     checkpointing: {
       // Maximum time to execute continuously before returning response
       maxRuntime: "300s", // Default: unlimited (0)
@@ -119,7 +148,6 @@ const advancedCheckpointing = inngest.createFunction(
       maxInterval: "10s" // Default: immediate
     }
   },
-  { event: "process/advanced" },
   async ({ event, step }) => {
     // With bufferedSteps: 3, first 3 steps execute without checkpointing
     const step1 = await step.run("step-1", () => process1(event.data));
@@ -144,11 +172,11 @@ const advancedCheckpointing = inngest.createFunction(
 const vercelFunction = inngest.createFunction(
   {
     id: "vercel-optimized",
+    triggers: [{ event: "process/vercel" }],
     checkpointing: {
       maxRuntime: "4m45s" // Leave 15s buffer for cleanup
     }
   },
-  { event: "process/vercel" },
   async ({ event, step }) => {
     /* ... */
   }
@@ -158,11 +186,11 @@ const vercelFunction = inngest.createFunction(
 const lambdaFunction = inngest.createFunction(
   {
     id: "lambda-optimized",
+    triggers: [{ event: "process/lambda" }],
     checkpointing: {
       maxRuntime: "14m30s" // Leave 30s buffer
     }
   },
-  { event: "process/lambda" },
   async ({ event, step }) => {
     /* ... */
   }
@@ -172,13 +200,13 @@ const lambdaFunction = inngest.createFunction(
 const serverFunction = inngest.createFunction(
   {
     id: "server-optimized",
+    triggers: [{ event: "process/server" }],
     checkpointing: {
       maxRuntime: "0", // Unlimited
       bufferedSteps: 5, // More aggressive buffering
       maxInterval: "30s"
     }
   },
-  { event: "process/server" },
   async ({ event, step }) => {
     /* ... */
   }
@@ -193,13 +221,13 @@ const serverFunction = inngest.createFunction(
 const aiWorkflow = inngest.createFunction(
   {
     id: "ai-workflow",
+    triggers: [{ event: "ai/process.requested" }],
     checkpointing: {
       maxRuntime: "10m",
       bufferedSteps: 2,
       maxInterval: "5s"
     }
   },
-  { event: "ai/process.requested" },
   async ({ event, step }) => {
     // Immediate execution for real-time feel
     const preprocessed = await step.run("preprocess-data", () => {
@@ -237,13 +265,13 @@ const aiWorkflow = inngest.createFunction(
 const dataProcessingPipeline = inngest.createFunction(
   {
     id: "data-processing-pipeline",
+    triggers: [{ event: "data/batch.received" }],
     checkpointing: {
       maxRuntime: "15m",
       bufferedSteps: 10, // High buffering for throughput
       maxInterval: "60s" // Less frequent checkpoints
     }
   },
-  { event: "data/batch.received" },
   async ({ event, step }) => {
     const batchId = event.data.batchId;
 
@@ -292,13 +320,13 @@ const dataProcessingPipeline = inngest.createFunction(
 const interactiveWorkflow = inngest.createFunction(
   {
     id: "interactive-workflow",
+    triggers: [{ event: "user/workflow.started" }],
     checkpointing: {
       maxRuntime: "5m",
       bufferedSteps: 1, // Immediate checkpoints for user feedback
       maxInterval: "2s"
     }
   },
-  { event: "user/workflow.started" },
   async ({ event, step }) => {
     const userId = event.data.userId;
 
@@ -368,9 +396,8 @@ const interactiveWorkflow = inngest.createFunction(
 const idealForCheckpointing = inngest.createFunction(
   {
     id: "ideal-checkpointing",
-    checkpointing: true
+    triggers: [{ event: "realtime/user.request" }]
   },
-  { event: "realtime/user.request" },
   async ({ event, step }) => {
     // Fast operations that benefit from immediate execution
     const validated = await step.run("validate", () => validate(event.data));
@@ -384,10 +411,10 @@ const idealForCheckpointing = inngest.createFunction(
 // ❌ NOT ideal for checkpointing: Very long-running steps
 const notIdealForCheckpointing = inngest.createFunction(
   {
-    id: "not-ideal-checkpointing"
-    // You can opt not to use checkpointing here
+    id: "not-ideal-checkpointing",
+    triggers: [{ event: "batch/long.process" }],
+    checkpointing: false // Disable for very long-running steps
   },
-  { event: "batch/long.process" },
   async ({ event, step }) => {
     // Very long-running operations
     const largeDataset = await step.run("fetch-large-dataset", () => {
@@ -434,7 +461,7 @@ const highThroughputConfig = {
 };
 ```
 
-## Current Limitations (Beta)
+## Current Limitations
 
 ### Known Limitations
 

--- a/skills/inngest-durable-functions/references/error-handling.md
+++ b/skills/inngest-durable-functions/references/error-handling.md
@@ -12,8 +12,7 @@ Comprehensive guide to handling errors, configuring retries, and building resili
 
 ```typescript
 const errorHandlingExample = inngest.createFunction(
-  { id: "error-handling-demo", retries: 3 },
-  { event: "demo/error-handling" },
+  { id: "error-handling-demo", retries: 3, triggers: [{ event: "demo/error-handling" }] },
   async ({ event, step }) => {
     try {
       // This step can error and retry up to 3 times
@@ -42,9 +41,9 @@ const errorHandlingExample = inngest.createFunction(
 const customRetries = inngest.createFunction(
   {
     id: "custom-retries",
-    retries: 10 // Each step gets up to 10 retries (11 total attempts)
+    retries: 10, // Each step gets up to 10 retries (11 total attempts)
+    triggers: [{ event: "critical/task" }]
   },
-  { event: "critical/task" },
   async ({ event, step, attempt }) => {
     // attempt is 0-indexed: 0, 1, 2, ..., 10
 
@@ -65,8 +64,7 @@ const customRetries = inngest.createFunction(
 
 ```typescript
 const independentRetries = inngest.createFunction(
-  { id: "independent-retries", retries: 4 },
-  { event: "multi/step.process" },
+  { id: "independent-retries", retries: 4, triggers: [{ event: "multi/step.process" }] },
   async ({ event, step }) => {
     // Step 1: Can retry up to 4 times independently
     const userData = await step.run("fetch-user", async () => {
@@ -97,8 +95,7 @@ const independentRetries = inngest.createFunction(
 import { NonRetriableError } from "inngest";
 
 const smartErrorHandling = inngest.createFunction(
-  { id: "smart-error-handling" },
-  { event: "process/user" },
+  { id: "smart-error-handling", triggers: [{ event: "process/user" }] },
   async ({ event, step }) => {
     const user = await step.run("validate-and-fetch-user", async () => {
       // Check if user exists
@@ -134,8 +131,7 @@ const smartErrorHandling = inngest.createFunction(
 
 ```typescript
 const commonNonRetriableErrors = inngest.createFunction(
-  { id: "non-retriable-examples" },
-  { event: "example/errors" },
+  { id: "non-retriable-examples", triggers: [{ event: "example/errors" }] },
   async ({ event, step }) => {
     // Authentication/Authorization errors
     await step.run("check-permissions", async () => {
@@ -180,8 +176,7 @@ const commonNonRetriableErrors = inngest.createFunction(
 import { RetryAfterError } from "inngest";
 
 const respectRateLimit = inngest.createFunction(
-  { id: "rate-limited-api" },
-  { event: "api/call.requested" },
+  { id: "rate-limited-api", triggers: [{ event: "api/call.requested" }] },
   async ({ event, step }) => {
     const result = await step.run("call-external-api", async () => {
       try {
@@ -215,8 +210,7 @@ const respectRateLimit = inngest.createFunction(
 
 ```typescript
 const dynamicRetryStrategy = inngest.createFunction(
-  { id: "dynamic-retry" },
-  { event: "process/adaptive" },
+  { id: "dynamic-retry", triggers: [{ event: "process/adaptive" }] },
   async ({ event, step, attempt }) => {
     const result = await step.run("adaptive-processing", async () => {
       try {
@@ -256,8 +250,7 @@ const dynamicRetryStrategy = inngest.createFunction(
 
 ```typescript
 const fallbackPattern = inngest.createFunction(
-  { id: "fallback-services" },
-  { event: "process/with-fallback" },
+  { id: "fallback-services", triggers: [{ event: "process/with-fallback" }] },
   async ({ event, step }) => {
     let result;
     let service = "primary";
@@ -298,6 +291,7 @@ const processWithFailureHandler = inngest.createFunction(
   {
     id: "process-with-failure-handler",
     retries: 3,
+    triggers: [{ event: "risky/process" }],
     onFailure: async ({ event, error }) => {
       // This runs when function fails after all retries
       // Access run_id from the failure event data
@@ -320,7 +314,6 @@ const processWithFailureHandler = inngest.createFunction(
       });
     }
   },
-  { event: "risky/process" },
   async ({ event, step }) => {
     // This might fail after retries
     const result = await step.run("risky-operation", async () => {
@@ -338,8 +331,7 @@ const processWithFailureHandler = inngest.createFunction(
 
 ```typescript
 const structuredErrorLogging = inngest.createFunction(
-  { id: "structured-error-logging" },
-  { event: "process/with-logging" },
+  { id: "structured-error-logging", triggers: [{ event: "process/with-logging" }] },
   async ({ event, step, logger }) => {
     const baseContext = {
       eventName: event.name,

--- a/skills/inngest-durable-functions/references/observability.md
+++ b/skills/inngest-durable-functions/references/observability.md
@@ -197,8 +197,7 @@ export const inngest = new Inngest({
 
 ```typescript
 const observableFunction = inngest.createFunction(
-  { id: "observable-function" },
-  { event: "process/observable" },
+  { id: "observable-function", triggers: [{ event: "process/observable" }] },
   async ({ event, step, logger, runId }) => {
     // Logger automatically includes function metadata when using .child()
     logger.info("Function started", {
@@ -260,8 +259,7 @@ const observableFunction = inngest.createFunction(
 
 ```typescript
 const correlatedLogging = inngest.createFunction(
-  { id: "correlated-logging" },
-  { event: "process/correlated" },
+  { id: "correlated-logging", triggers: [{ event: "process/correlated" }] },
   async ({ event, step, logger, runId }) => {
     // Create correlation context
     const correlationId = event.data.correlationId || runId;
@@ -339,8 +337,7 @@ const correlatedLogging = inngest.createFunction(
 import { trace, context, SpanStatusCode } from "@opentelemetry/api";
 
 const customTracing = inngest.createFunction(
-  { id: "custom-tracing" },
-  { event: "process/traced" },
+  { id: "custom-tracing", triggers: [{ event: "process/traced" }] },
   async ({ event, step }) => {
     const tracer = trace.getTracer("my-app");
 
@@ -473,8 +470,7 @@ export const inngest = new Inngest({
 
 ```typescript
 const healthCheck = inngest.createFunction(
-  { id: "health-check" },
-  { cron: "*/5 * * * *" }, // Every 5 minutes
+  { id: "health-check", triggers: [{ cron: "*/5 * * * *" }] }, // Every 5 minutes
   async ({ step, logger }) => {
     const healthStatus = {
       services: {}
@@ -543,8 +539,7 @@ const healthCheck = inngest.createFunction(
 
 ```typescript
 const debugFunction = inngest.createFunction(
-  { id: "debug-function" },
-  { event: "debug/test" },
+  { id: "debug-function", triggers: [{ event: "debug/test" }] },
   async ({ event, step, logger }) => {
     // Enable debug logging conditionally
     const isDebugMode =

--- a/skills/inngest-durable-functions/references/step-execution.md
+++ b/skills/inngest-durable-functions/references/step-execution.md
@@ -19,8 +19,7 @@ Deep dive into how Inngest executes steps, handles memoization, and manages stat
 
 ```typescript
 const importContacts = inngest.createFunction(
-  { id: "import-contacts" },
-  { event: "contacts/csv.uploaded" },
+  { id: "import-contacts", triggers: [{ event: "contacts/csv.uploaded" }] },
   async ({ event, step }) => {
     // HTTP Request #1 - Executes and returns
     const rows = await step.run("parse-csv", async () => {
@@ -107,8 +106,7 @@ await step.run("process-user-data", () => processUserData()); // Will re-execute
 
 ```typescript
 const robustProcess = inngest.createFunction(
-  { id: "robust-process" },
-  { event: "process/data" },
+  { id: "robust-process", triggers: [{ event: "process/data" }] },
   async ({ event, step }) => {
     // Step 1: Completes successfully
     const data = await step.run("fetch-external-data", async () => {
@@ -139,8 +137,7 @@ const robustProcess = inngest.createFunction(
 
 ```typescript
 const parallelProcess = inngest.createFunction(
-  { id: "parallel-process" },
-  { event: "process/parallel" },
+  { id: "parallel-process", triggers: [{ event: "process/parallel" }] },
   async ({ event, step }) => {
     const userData = await step.run("fetch-user", () => {
       return getUserData(event.data.userId);
@@ -162,8 +159,7 @@ const parallelProcess = inngest.createFunction(
 
 ```typescript
 const conditionalSteps = inngest.createFunction(
-  { id: "conditional-steps" },
-  { event: "user/signup" },
+  { id: "conditional-steps", triggers: [{ event: "user/signup" }] },
   async ({ event, step }) => {
     const user = await step.run("create-user", () => {
       return createUser(event.data);
@@ -194,8 +190,7 @@ const conditionalSteps = inngest.createFunction(
 
 ```typescript
 const dynamicSteps = inngest.createFunction(
-  { id: "dynamic-steps" },
-  { event: "batch/process" },
+  { id: "dynamic-steps", triggers: [{ event: "batch/process" }] },
   async ({ event, step }) => {
     const items = await step.run("fetch-items", () => {
       return getItemsToProcess(event.data.batchId);
@@ -225,8 +220,7 @@ const dynamicSteps = inngest.createFunction(
 ```typescript
 // ❌ TOO GRANULAR: Many small steps
 const tooGranular = inngest.createFunction(
-  { id: "too-granular" },
-  { event: "process/data" },
+  { id: "too-granular", triggers: [{ event: "process/data" }] },
   async ({ event, step }) => {
     const a = await step.run("step-1", () => simpleOperation1());
     const b = await step.run("step-2", () => simpleOperation2(a));
@@ -237,8 +231,7 @@ const tooGranular = inngest.createFunction(
 
 // ✅ BETTER: Logical grouping
 const betterGrouping = inngest.createFunction(
-  { id: "better-grouping" },
-  { event: "process/data" },
+  { id: "better-grouping", triggers: [{ event: "process/data" }] },
   async ({ event, step }) => {
     const processedData = await step.run("process-data-batch", () => {
       const a = simpleOperation1();
@@ -271,8 +264,7 @@ const betterGrouping = inngest.createFunction(
 // - Simple conditionals
 
 const goodPatterns = inngest.createFunction(
-  { id: "good-patterns" },
-  { event: "process/user" },
+  { id: "good-patterns", triggers: [{ event: "process/user" }] },
   async ({ event, step }) => {
     // ✅ Regular code: deterministic validation
     if (!event.data.email || !event.data.userId) {

--- a/skills/inngest-events/SKILL.md
+++ b/skills/inngest-events/SKILL.md
@@ -176,8 +176,7 @@ await inngest.send({
 
 // Multiple functions respond to same event
 const sendWelcomeEmail = inngest.createFunction(
-  { id: "send-welcome-email" },
-  { event: "user/signup.completed" },
+  { id: "send-welcome-email", triggers: [{ event: "user/signup.completed" }] },
   async ({ event, step }) => {
     await step.run("send-email", async () => {
       return sendEmail({
@@ -189,8 +188,7 @@ const sendWelcomeEmail = inngest.createFunction(
 );
 
 const createTrialSubscription = inngest.createFunction(
-  { id: "create-trial" },
-  { event: "user/signup.completed" },
+  { id: "create-trial", triggers: [{ event: "user/signup.completed" }] },
   async ({ event, step }) => {
     await step.run("create-subscription", async () => {
       return stripe.subscriptions.create({
@@ -202,8 +200,7 @@ const createTrialSubscription = inngest.createFunction(
 );
 
 const addToCrm = inngest.createFunction(
-  { id: "add-to-crm" },
-  { event: "user/signup.completed" },
+  { id: "add-to-crm", triggers: [{ event: "user/signup.completed" }] },
   async ({ event, step }) => {
     await step.run("crm-sync", async () => {
       return crm.contacts.create({
@@ -228,8 +225,7 @@ In expressions, `event` = the **original** triggering event, `async` = the **new
 
 ```typescript
 const orchestrateOnboarding = inngest.createFunction(
-  { id: "orchestrate-onboarding" },
-  { event: "user/signup.completed" },
+  { id: "orchestrate-onboarding", triggers: [{ event: "user/signup.completed" }] },
   async ({ event, step }) => {
     // Fan out to multiple services
     await step.sendEvent("fan-out", [
@@ -284,8 +280,7 @@ Inngest emits system events for function lifecycle monitoring:
 
 ```typescript
 const handleFailures = inngest.createFunction(
-  { id: "handle-failed-functions" },
-  { event: "inngest/function.failed" },
+  { id: "handle-failed-functions", triggers: [{ event: "inngest/function.failed" }] },
   async ({ event, step }) => {
     const { function_id, run_id, error } = event.data;
 
@@ -381,8 +376,7 @@ await inngest.send(events);
 
 ```typescript
 inngest.createFunction(
-  { id: "process-order" },
-  { event: "order/placed" },
+  { id: "process-order", triggers: [{ event: "order/placed" }] },
   async ({ event, step }) => {
     // Use step.sendEvent() instead of inngest.send() in functions
     // for reliability and deduplication

--- a/skills/inngest-flow-control/SKILL.md
+++ b/skills/inngest-flow-control/SKILL.md
@@ -31,9 +31,9 @@ Master Inngest flow control mechanisms to manage resources, prevent overloading 
 inngest.createFunction(
   {
     id: "process-images",
-    concurrency: 5
+    concurrency: 5,
+    triggers: [{ event: "media/image.uploaded" }]
   },
-  { event: "media/image.uploaded" },
   async ({ event, step }) => {
     // Only 5 steps can execute simultaneously
     await step.run("resize", () => resizeImage(event.data.imageUrl));
@@ -54,9 +54,9 @@ inngest.createFunction(
         key: "event.data.user_id",
         limit: 1
       }
-    ]
+    ],
+    triggers: [{ event: "user/profile.updated" }]
   },
-  { event: "user/profile.updated" },
   async ({ event, step }) => {
     // Only 1 step per user can execute at once
     // Prevents race conditions in user-specific operations
@@ -76,9 +76,9 @@ inngest.createFunction(
         key: `"openai"`,
         limit: 60
       }
-    ]
+    ],
+    triggers: [{ event: "ai/summary.requested" }]
   },
-  { event: "ai/summary.requested" },
   async ({ event, step }) => {
     // Share 60 concurrent OpenAI calls across all functions
   }
@@ -106,9 +106,9 @@ inngest.createFunction(
       period: "60s", // per minute
       burst: 5, // plus 5 immediate bursts
       key: "event.data.customer_id" // per customer
-    }
+    },
+    triggers: [{ event: "crm/contact.updated" }]
   },
-  { event: "crm/contact.updated" },
   async ({ event, step }) => {
     // Respects CRM API rate limits: 10 calls/min per customer
     await step.run("sync", () => crmApi.updateContact(event.data));
@@ -137,9 +137,9 @@ inngest.createFunction(
       limit: 1,
       period: "4h",
       key: "event.data.webhook_id"
-    }
+    },
+    triggers: [{ event: "webhook/data.received" }]
   },
-  { event: "webhook/data.received" },
   async ({ event, step }) => {
     // Process each webhook only once per 4 hours
     // Prevents duplicate webhook spam
@@ -165,9 +165,9 @@ inngest.createFunction(
       period: "5m", // Wait 5min after last edit
       key: "event.data.document_id",
       timeout: "30m" // Force save after 30min max
-    }
+    },
+    triggers: [{ event: "document/content.changed" }]
   },
-  { event: "document/content.changed" },
   async ({ event, step }) => {
     // Saves document only after user stops editing
     // Uses the LAST event received
@@ -193,9 +193,9 @@ inngest.createFunction(
     priority: {
       // VIP users get priority up to 120 seconds ahead
       run: "event.data.user_tier == 'vip' ? 120 : 0"
-    }
+    },
+    triggers: [{ event: "order/placed" }]
   },
-  { event: "order/placed" },
   async ({ event, step }) => {
     // VIP orders jump ahead in the queue
   }
@@ -214,9 +214,9 @@ inngest.createFunction(
         event.data.severity == 'high' ? 120 :
         event.data.user_plan == 'enterprise' ? 60 : 0
       `
-    }
+    },
+    triggers: [{ event: "support/ticket.created" }]
   },
-  { event: "support/ticket.created" },
   async ({ event, step }) => {
     // Critical tickets get highest priority (300s ahead)
     // High severity: 120s ahead
@@ -239,9 +239,9 @@ inngest.createFunction(
     singleton: {
       key: "event.data.database_id",
       mode: "skip"
-    }
+    },
+    triggers: [{ event: "backup/requested" }]
   },
-  { event: "backup/requested" },
   async ({ event, step }) => {
     // Skip new backups if one is already running for this database
     await step.run("backup", () => performBackup(event.data.database_id));
@@ -258,9 +258,9 @@ inngest.createFunction(
     singleton: {
       key: "event.data.user_id",
       mode: "cancel"
-    }
+    },
+    triggers: [{ event: "user/data.changed" }]
   },
-  { event: "user/data.changed" },
   async ({ event, step }) => {
     // Cancel previous sync and start with latest data
     await step.run("sync", () => syncUserData(event.data));
@@ -282,9 +282,9 @@ inngest.createFunction(
       // `key` groups events into separate batches per unique value
       // This is different from expressions `if` which filters events
       key: "event.data.campaign_id" // Batch per campaign
-    }
+    },
+    triggers: [{ event: "email/send.queued" }]
   },
-  { event: "email/send.queued" },
   async ({ events, step }) => {
     // Process array of events together
     const emails = events.map((evt) => ({
@@ -322,9 +322,9 @@ inngest.createFunction(
     // VIP users get priority
     priority: {
       run: "event.data.plan == 'pro' ? 60 : 0"
-    }
+    },
+    triggers: [{ event: "ai/image.generate" }]
   },
-  { event: "ai/image.generate" },
   async ({ event, step }) => {
     // Combines multiple flow controls for optimal resource usage
   }

--- a/skills/inngest-middleware/SKILL.md
+++ b/skills/inngest-middleware/SKILL.md
@@ -42,9 +42,9 @@ inngest.createFunction(
     middleware: [
       authMiddleware, // Runs 3rd
       metricsMiddleware // Runs 4th
-    ]
+    ],
+    triggers: [{ event: "test" }]
   },
-  { event: "test" },
   async () => {
     /* function code */
   }
@@ -145,8 +145,7 @@ const inngest = new Inngest({
 
 // Functions automatically get injected dependencies
 inngest.createFunction(
-  { id: "ai-summary" },
-  { event: "document/uploaded" },
+  { id: "ai-summary", triggers: [{ event: "document/uploaded" }] },
   async ({ event, openai, db }) => {
     // Dependencies available in function context
     const summary = await openai.chat.completions.create({

--- a/skills/inngest-middleware/SKILL.md
+++ b/skills/inngest-middleware/SKILL.md
@@ -9,7 +9,7 @@ Master Inngest middleware to handle cross-cutting concerns like logging, error t
 
 > **These skills are focused on TypeScript.** For Python or Go, refer to the [Inngest documentation](https://www.inngest.com/llms.txt) for language-specific guidance. Core concepts apply across all languages.
 
-> **Note:** The middleware system was significantly rewritten in v4. The lifecycle hooks documented here reflect the v4 API. If migrating from v3, consult the [migration guide](https://www.inngest.com/docs/reference/typescript/v4/migrations/v3-to-v4) for details on breaking changes.
+> **Note:** The middleware system was significantly rewritten in v4. The lifecycle hooks documented here reflect the v4 API. If migrating from v3, consult the [migration guide](https://www.inngest.com/docs-markdown/reference/typescript/v4/migrations/v3-to-v4) for details on breaking changes.
 
 ## What is Middleware?
 
@@ -180,7 +180,7 @@ const inngest = new Inngest({
   id: "my-app",
   middleware: [
     encryptionMiddleware({
-      key: process.env.ENCRYPTION_KEY,
+      key: process.env.ENCRYPTION_KEY
     })
   ]
 });
@@ -198,7 +198,9 @@ npm install @inngest/middleware-sentry
 import * as Sentry from "@sentry/node";
 import { sentryMiddleware } from "@inngest/middleware-sentry";
 
-Sentry.init({ /* your Sentry config */ });
+Sentry.init({
+  /* your Sentry config */
+});
 
 const inngest = new Inngest({
   id: "my-app",

--- a/skills/inngest-middleware/SKILL.md
+++ b/skills/inngest-middleware/SKILL.md
@@ -9,6 +9,8 @@ Master Inngest middleware to handle cross-cutting concerns like logging, error t
 
 > **These skills are focused on TypeScript.** For Python or Go, refer to the [Inngest documentation](https://www.inngest.com/llms.txt) for language-specific guidance. Core concepts apply across all languages.
 
+> **Note:** The middleware system was significantly rewritten in v4. The lifecycle hooks documented here reflect the v4 API. If migrating from v3, consult the [migration guide](https://www.inngest.com/docs/reference/typescript/v4/migrations/v3-to-v4) for details on breaking changes.
+
 ## What is Middleware?
 
 Middleware allows code to run at various points in an Inngest client's lifecycle - during function execution, event sending, and more. Think of middleware as hooks into the Inngest execution pipeline.

--- a/skills/inngest-middleware/references/dependency-injection.md
+++ b/skills/inngest-middleware/references/dependency-injection.md
@@ -30,8 +30,7 @@ const inngest = new Inngest({
 
 // Functions automatically get injected dependencies
 inngest.createFunction(
-  { id: "ai-summary" },
-  { event: "document/uploaded" },
+  { id: "ai-summary", triggers: [{ event: "document/uploaded" }] },
   async ({ event, openai, db, redis }) => {
     // All dependencies available in function context
     const summary = await openai.chat.completions.create({
@@ -102,8 +101,7 @@ const inngest = new Inngest({
 
 // Function with injected dependencies
 inngest.createFunction(
-  { id: "process-payment" },
-  { event: "checkout/completed" },
+  { id: "process-payment", triggers: [{ event: "checkout/completed" }] },
   async ({ event, stripe, analytics, notifications }) => {
     // Create payment intent
     const paymentIntent = await stripe.paymentIntents.create({

--- a/skills/inngest-setup/SKILL.md
+++ b/skills/inngest-setup/SKILL.md
@@ -38,8 +38,10 @@ Create a shared client file that you'll import throughout your codebase:
 import { Inngest } from "inngest";
 
 export const inngest = new Inngest({
-  id: "my-app" // Unique identifier for your application (hyphenated slug)
+  id: "my-app", // Unique identifier for your application (hyphenated slug)
 });
+// In development, set INNGEST_DEV=1 env var or use isDev: true
+// In production, INNGEST_SIGNING_KEY is required (v4 defaults to Cloud mode)
 ```
 
 ### Key Configuration Options
@@ -47,41 +49,48 @@ export const inngest = new Inngest({
 - **`id`** (required): Unique identifier for your app. Use a hyphenated slug like `"my-app"` or `"user-service"`
 - **`eventKey`**: Event key for sending events (prefer `INNGEST_EVENT_KEY` env var)
 - **`env`**: Environment name for Branch Environments
-- **`isDev`**: Force Dev mode (`true`) or Cloud mode (`false`)
+- **`isDev`**: Force Dev mode (`true`) or Cloud mode (`false`). **v4 defaults to Cloud mode**, so set `isDev: true` or `INNGEST_DEV=1` for local development
+- **`signingKey`**: Signing key for production (prefer `INNGEST_SIGNING_KEY` env var). Moved from `serve()` to client in v4
+- **`signingKeyFallback`**: Fallback signing key for key rotation (prefer `INNGEST_SIGNING_KEY_FALLBACK` env var)
+- **`baseUrl`**: Custom Inngest API base URL (prefer `INNGEST_BASE_URL` env var)
 - **`logger`**: Custom logger instance (e.g. winston, pino) — enables `logger` in function context
 - **`middleware`**: Array of middleware (see **inngest-middleware** skill)
-- **`schemas`**: Use `EventSchemas` for typed events (see **inngest-events** skill)
 
-### Typed Events with EventSchemas
+### Typed Events with eventType()
 
 ```typescript
-import { Inngest, EventSchemas } from "inngest";
+import { Inngest, eventType } from "inngest";
+import { z } from "zod";
 
-type Events = {
-  "user/signup.completed": {
-    data: {
-      userId: string;
-      email: string;
-      plan: "free" | "pro";
-    };
-  };
-  "order/placed": {
-    data: {
-      orderId: string;
-      amount: number;
-    };
-  };
-};
-
-export const inngest = new Inngest({
-  id: "my-app",
-  schemas: new EventSchemas().fromRecord<Events>()
+const signupCompleted = eventType("user/signup.completed", {
+  schema: z.object({
+    userId: z.string(),
+    email: z.string(),
+    plan: z.enum(["free", "pro"]),
+  }),
 });
 
-// Now event data is fully typed in functions:
-// inngest.createFunction({ id: "handle-signup" }, { event: "user/signup.completed" },
-//   async ({ event }) => { event.data.userId /* typed as string */ }
-// );
+const orderPlaced = eventType("order/placed", {
+  schema: z.object({
+    orderId: z.string(),
+    amount: z.number(),
+  }),
+});
+
+export const inngest = new Inngest({ id: "my-app" });
+
+// Use event types as triggers for full type safety:
+inngest.createFunction(
+  { id: "handle-signup", triggers: [signupCompleted] },
+  async ({ event }) => { event.data.userId /* typed as string */ }
+);
+
+// Use event types when sending events:
+await inngest.send(signupCompleted.create({
+  userId: "user_123",
+  email: "user@example.com",
+  plan: "pro",
+}));
 ```
 
 ### Environment Variables Setup

--- a/skills/inngest-setup/SKILL.md
+++ b/skills/inngest-setup/SKILL.md
@@ -38,9 +38,9 @@ Create a shared client file that you'll import throughout your codebase:
 import { Inngest } from "inngest";
 
 export const inngest = new Inngest({
-  id: "my-app", // Unique identifier for your application (hyphenated slug)
+  id: "my-app" // Unique identifier for your application (hyphenated slug)
 });
-// In development, set INNGEST_DEV=1 env var or use isDev: true
+// In development, you must set the INNGEST_DEV=1 env var or use isDev: true
 // In production, INNGEST_SIGNING_KEY is required (v4 defaults to Cloud mode)
 ```
 
@@ -66,15 +66,15 @@ const signupCompleted = eventType("user/signup.completed", {
   schema: z.object({
     userId: z.string(),
     email: z.string(),
-    plan: z.enum(["free", "pro"]),
-  }),
+    plan: z.enum(["free", "pro"])
+  })
 });
 
 const orderPlaced = eventType("order/placed", {
   schema: z.object({
     orderId: z.string(),
-    amount: z.number(),
-  }),
+    amount: z.number()
+  })
 });
 
 export const inngest = new Inngest({ id: "my-app" });
@@ -82,15 +82,19 @@ export const inngest = new Inngest({ id: "my-app" });
 // Use event types as triggers for full type safety:
 inngest.createFunction(
   { id: "handle-signup", triggers: [signupCompleted] },
-  async ({ event }) => { event.data.userId /* typed as string */ }
+  async ({ event }) => {
+    event.data.userId; /* typed as string */
+  }
 );
 
 // Use event types when sending events:
-await inngest.send(signupCompleted.create({
-  userId: "user_123",
-  email: "user@example.com",
-  plan: "pro",
-}));
+await inngest.send(
+  signupCompleted.create({
+    userId: "user_123",
+    email: "user@example.com",
+    plan: "pro"
+  })
+);
 ```
 
 ### Environment Variables Setup

--- a/skills/inngest-setup/SKILL.md
+++ b/skills/inngest-setup/SKILL.md
@@ -192,7 +192,6 @@ For long-running applications that maintain persistent connections:
 
 ```typescript
 // src/worker.ts
-// Note: inngest/connect requires inngest SDK v3.27+
 import { connect } from "inngest/connect";
 import { inngest } from "./inngest/client";
 import { myFunction } from "./inngest/functions";
@@ -218,6 +217,11 @@ import { myFunction } from "./inngest/functions";
 - Long-running server environment (not serverless)
 - `INNGEST_SIGNING_KEY` and `INNGEST_EVENT_KEY` for production
 - Set the `appVersion` parameter on the `Inngest` client for production to support rolling deploys
+
+**v4 Connect Changes:**
+
+- **Worker thread isolation** is enabled by default — WebSocket connections execute in a worker thread to prevent event loop starvation. Set `isolateExecution: false` to use a single process (or `INNGEST_CONNECT_ISOLATE_EXECUTION=false`)
+- **`rewriteGatewayEndpoint`** callback has been replaced with the `gatewayUrl` string option (or `INNGEST_CONNECT_GATEWAY_URL` env var)
 
 ## Step 5: Organizing with Apps
 

--- a/skills/inngest-setup/SKILL.md
+++ b/skills/inngest-setup/SKILL.md
@@ -178,6 +178,8 @@ app.use(
 - **AWS Lambda**: Use `inngest/lambda`
 - For all other frameworks, check the `serve` reference here: https://www.inngest.com/docs-markdown/learn/serving-inngest-functions
 
+**⚠️ v4 Change:** Options like `signingKey`, `signingKeyFallback`, and `baseUrl` are now configured on the `Inngest` client constructor, not on `serve()`. The `serve()` function only accepts `client`, `functions`, and `streaming`.
+
 **⚠️ Common Gotcha**: Always use `/api/inngest` as your endpoint path. This enables automatic discovery. If you must use a different path, you'll need to configure discovery manually with the `-u` flag.
 
 ## Step 4B: Connect as Worker (WebSocket Mode)

--- a/skills/inngest-steps/SKILL.md
+++ b/skills/inngest-steps/SKILL.md
@@ -216,12 +216,12 @@ import { referenceFunction } from "inngest";
 
 const externalFn = referenceFunction({
   appId: "other-app",
-  functionId: "other-fn",
+  functionId: "other-fn"
 });
 
 const result = await step.invoke("call-external", {
   function: externalFn,
-  data: { key: "value" },
+  data: { key: "value" }
 });
 ```
 
@@ -266,7 +266,7 @@ await step.run("process-products", () => {
 
 ### Parallel Execution
 
-Use Promise.all for parallel steps. **In v4, parallel step execution is optimized by default** — Inngest batches parallel steps to reduce HTTP requests.
+Use Promise.all for parallel steps. **In v4, parallel step execution is optimized by default**
 
 ```typescript
 // Create steps without awaiting
@@ -309,7 +309,7 @@ export default inngest.createFunction(
 const winner = await group.parallel(async () => {
   return Promise.race([
     step.run("fast-service", () => callFastService()),
-    step.run("slow-service", () => callSlowService()),
+    step.run("slow-service", () => callSlowService())
   ]);
 });
 

--- a/skills/inngest-steps/SKILL.md
+++ b/skills/inngest-steps/SKILL.md
@@ -18,8 +18,7 @@ Build robust, durable workflows with Inngest's step methods. Each step is a sepa
 ```typescript
 // ❌ WRONG - will run 4 times
 export default inngest.createFunction(
-  { id: "bad-example" },
-  { event: "test" },
+  { id: "bad-example", triggers: [{ event: "test" }] },
   async ({ step }) => {
     console.log("This logs 4 times!"); // Outside step = bad
     await step.run("a", () => console.log("a"));
@@ -30,8 +29,7 @@ export default inngest.createFunction(
 
 // ✅ CORRECT - logs once each
 export default inngest.createFunction(
-  { id: "good-example" },
-  { event: "test" },
+  { id: "good-example", triggers: [{ event: "test" }] },
   async ({ step }) => {
     await step.run("log-hello", () => console.log("hello"));
     await step.run("a", () => console.log("a"));
@@ -199,8 +197,7 @@ Call other functions and handle their results. Perfect for composition.
 
 ```typescript
 const computeSquare = inngest.createFunction(
-  { id: "compute-square" },
-  { event: "calculate/square" },
+  { id: "compute-square", triggers: [{ event: "calculate/square" }] },
   async ({ event }) => {
     return { result: event.data.number * event.data.number };
   }
@@ -254,7 +251,7 @@ await step.run("process-products", () => {
 
 ### Parallel Execution
 
-Use Promise.all for parallel steps.
+Use Promise.all for parallel steps. **In v4, parallel step execution is optimized by default** — Inngest batches parallel steps to reduce HTTP requests.
 
 ```typescript
 // Create steps without awaiting
@@ -277,13 +274,12 @@ const [emailId, crmRecord, subscription] = await Promise.all([
   createSubscription
 ]);
 
-// Optimization: Enable optimizeParallelism for many parallel steps
+// Parallel steps are optimized by default in v4
 export default inngest.createFunction(
   {
     id: "parallel-heavy-function",
-    optimizeParallelism: true // Reduces HTTP requests by ~50%
+    triggers: [{ event: "process/batch" }]
   },
-  { event: "process/batch" },
   async ({ event, step }) => {
     const results = await Promise.all(
       event.data.items.map((item, i) =>
@@ -292,6 +288,19 @@ export default inngest.createFunction(
     );
   }
 );
+
+// ⚠️ Promise.race() behavior with v4's optimized parallelism:
+// All promises settle before race resolves. Use group.parallel() for true race:
+const winner = await group.parallel(async () => {
+  return Promise.race([
+    step.run("fast-service", () => callFastService()),
+    step.run("slow-service", () => callSlowService()),
+  ]);
+});
+
+// To disable optimized parallelism if needed:
+// At the client level: new Inngest({ id: "app", optimizeParallelism: false })
+// At the function level: { id: "fn", optimizeParallelism: false, triggers: [...] }
 ```
 
 See **inngest-flow-control** for concurrency and throttling options.
@@ -302,8 +311,7 @@ Perfect for batch processing with parallel steps.
 
 ```typescript
 export default inngest.createFunction(
-  { id: "process-large-dataset" },
-  { event: "data/process.large" },
+  { id: "process-large-dataset", triggers: [{ event: "data/process.large" }] },
   async ({ event, step }) => {
     const chunks = chunkArray(event.data.items, 10);
 
@@ -327,9 +335,9 @@ export default inngest.createFunction(
 **🔄 Function Re-execution:** Code outside steps runs on every step execution
 **⏰ Event Timing:** waitForEvent only catches events sent AFTER the step runs
 **🔢 Step Limits:** Max 1,000 steps per function, 4MB per step output, 32MB per function run in total
-**📨 HTTP Requests:** With `serve`, use `checkpointing` to reduce HTTP requests
+**📨 HTTP Requests:** Checkpointing is enabled by default in v4, reducing HTTP overhead. For serverless platforms, configure `maxRuntime` on the client
 **🔁 Step IDs:** Can be reused in loops - Inngest handles counters
-**⚡ Parallelism:** Use Promise.all, consider optimizeParallelism for many steps
+**⚡ Parallelism:** Use Promise.all for parallel steps (optimized by default in v4). Note that Promise.race() waits for all promises to settle — use `group.parallel()` for true race semantics
 
 ## Common Use Cases
 

--- a/skills/inngest-steps/SKILL.md
+++ b/skills/inngest-steps/SKILL.md
@@ -210,7 +210,22 @@ const square = await step.invoke("get-square", {
 });
 
 console.log(square.result); // 16, fully typed!
+
+// For cross-app invocation (when you can't import the function directly):
+import { referenceFunction } from "inngest";
+
+const externalFn = referenceFunction({
+  appId: "other-app",
+  functionId: "other-fn",
+});
+
+const result = await step.invoke("call-external", {
+  function: externalFn,
+  data: { key: "value" },
+});
 ```
+
+**Warning: v4 Breaking Change:** String function IDs (e.g., `function: "my-app-other-fn"`) are no longer supported in `step.invoke()`. Use an imported function reference or `referenceFunction()` for cross-app calls.
 
 **Great for:**
 


### PR DESCRIPTION
Related to: https://www.inngest.com/docs/reference/typescript/v4/migrations/v3-to-v4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates all skills docs to the TypeScript SDK v4. Switches to the new triggers API, documents default checkpointing, refreshes setup/typing/logging/invocation behavior, and adds v4 `connect` notes.

- **Migration**
  - Use `triggers` in `createFunction` options: `{ id, triggers: [...] }` (remove second-arg trigger). Updated for events, cron, multiple triggers, `cancelOn`, and `timeouts`.
  - Checkpointing is on by default. Configure `checkpointing.maxRuntime` for serverless; disable per function with `checkpointing: false`. Removed “Beta” notes and clarified limits.
  - Parallel steps are optimized by default. Note `Promise.race()` semantics and suggest `group.parallel()` for true race; show how to disable optimization at client or function.
  - Client setup: v4 defaults to Cloud. Use `INNGEST_DEV=1` or `isDev: true` for local. Move `signingKey` (and `signingKeyFallback`) to the `new Inngest()` client; support `baseUrl`. Prefer env vars (`INNGEST_SIGNING_KEY`, etc.).
  - Logging: `logLevel` was removed. Use the `logger` option with `ConsoleLogger` or a custom logger.
  - Typed events now use `eventType()` with `zod`, replacing `EventSchemas`. Examples show typed triggers and `send()` via `eventType.create()`.
  - Invocation: `step.invoke()` now requires a function reference (imported or via `referenceFunction({ appId, functionId })`). String IDs are no longer supported.
  - Middleware: Updated to the v4 lifecycle and APIs; added migration notes and a v4 rewrite notice.
  - Connect: Updated `connect` docs. Worker thread isolation is enabled by default (set `isolateExecution: false` to opt out) and `rewriteGatewayEndpoint` is replaced by the `gatewayUrl` option.

<sup>Written for commit d89048e73de59ea99a9613baceb3fa091d387e28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

