### PR TITLE
fix: missing quotes on flow-control and realtime skills

### DIFF
--- a/skills/inngest-flow-control/SKILL.md
+++ b/skills/inngest-flow-control/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inngest-flow-control
-description: Use when handling external API rate limits (e.g., OpenAI 429s, HubSpot or Stripe rate limits), preventing duplicate work from rapid event bursts (debouncing user actions), spreading load over time, ensuring per-tenant fairness, processing events in batches, limiting concurrent runs of the same operation, or assigning priority to important runs. Covers Inngest flow control: concurrency limits with keys, throttling, rate limiting, debounce, priority, singleton, and event batching.
+description: "Use when handling external API rate limits (e.g., OpenAI 429s, HubSpot or Stripe rate limits), preventing duplicate work from rapid event bursts (debouncing user actions), spreading load over time, ensuring per-tenant fairness, processing events in batches, limiting concurrent runs of the same operation, or assigning priority to important runs. Covers Inngest flow control: concurrency limits with keys, throttling, rate limiting, debounce, priority, singleton, and event batching."
 ---
 
 # Inngest Flow Control

--- a/skills/inngest-realtime/SKILL.md
+++ b/skills/inngest-realtime/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inngest-realtime
-description: Use when streaming durable workflow updates to a UI in real time — live order status pages that animate as steps complete, AI agent token streaming from a function to the browser, log tailing for long-running jobs, or human-in-the-loop approval flows that publish a prompt and wait for a user reply. Covers Inngest v4 native realtime: defining typed channels, publishing from inside step.run, minting subscription tokens via server actions, and consuming the stream from React/Next.js client components.
+description: "Use when streaming durable workflow updates to a UI in real time — live order status pages that animate as steps complete, AI agent token streaming from a function to the browser, log tailing for long-running jobs, or human-in-the-loop approval flows that publish a prompt and wait for a user reply. Covers Inngest v4 native realtime: defining typed channels, publishing from inside step.run, minting subscription tokens via server actions, and consuming the stream from React/Next.js client components."
 ---
 
 # Inngest Realtime


### PR DESCRIPTION
This pull request makes a minor formatting update to the `description` fields in two skill markdown files. The only change is the addition of quotation marks around the `description` values to ensure proper YAML formatting.

Certain skills managers can throw errors when the frontmatter is invalid YAML. This can be seen on GitHub (as it shows frontmatter):
https://github.com/inngest/inngest-skills/blob/c1996f94a1c39a10a56bb848a2ce7701bfe7346d/skills/inngest-flow-control/SKILL.md
https://github.com/inngest/inngest-skills/blob/c1996f94a1c39a10a56bb848a2ce7701bfe7346d/skills/inngest-realtime/SKILL.md

<img width="1309" height="699" alt="image" src="https://github.com/user-attachments/assets/b7092286-d278-433b-91e7-785ab1304862" />


- Documentation formatting:
  * Added double quotes around the `description` fields in `skills/inngest-flow-control/SKILL.md` and `skills/inngest-realtime/SKILL.md` for YAML compatibility. [[1]](diffhunk://#diff-5026e46e9cdb2c039e758cf04746aafb008dc0fd21715a417deba22348e8504aL3-R3) [[2]](diffhunk://#diff-220662d48798ebe46f0f6d8b8caad1ffdf5796fb3c2b51755038cf82a06ad643L3-R3)