### PR TITLE
feat: upstream agents, brownfield-audit, and v3→v4 migration skills from codex plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Inngest Agent Skills
 
-Agent Skills for building with [Inngest](https://www.inngest.com)'s durable execution platform. These skills give AI coding agents comprehensive guidance on creating reliable, fault-tolerant applications: durable functions, events, steps, flow control, middleware, realtime, CLI operations, and REST API fallback.
+Agent Skills for building with [Inngest](https://www.inngest.com)'s durable execution platform. These skills give AI coding agents comprehensive guidance on creating reliable, fault-tolerant applications: durable functions, events, steps, flow control, middleware, realtime, AI agents, CLI operations, REST API fallback, brownfield audits, and SDK migrations.
 
 > **Looking for the full agent-plugin experience?** Use the [Inngest plugin for Claude Code](https://github.com/inngest/inngest-claude-code-plugin) or the [Inngest plugin for Codex](https://github.com/inngest/inngest-codex-plugin) — same shared skills, plus plugin-specific MCP, eval harnesses, commands, or agents.
 
@@ -27,6 +27,9 @@ Learn more about [Agent Skills](https://agentskills.io).
 | [inngest-cli](./skills/inngest-cli/)                             | Install and use the Inngest CLI and Dev Server               | Dev server, auto-discovery, Docker, testing, MCP server, deployment workflow   |
 | [inngest-api-cli](./skills/inngest-api-cli/)                     | Operate Inngest API resources from the terminal             | `inngest api`, Cloud debugging, traces, event runs, invocation, Insights       |
 | [inngest-api](./skills/inngest-api/)                             | Use REST API v2 and OpenAPI fallback                        | Raw HTTP, API keys, docs lookup, request shapes, pagination, secret redaction  |
+| [inngest-agents](./skills/inngest-agents/)                       | Build durable AI agents and agentic workflows               | AgentKit, `step.ai`, tool calls, multi-agent networks, human approval, realtime |
+| [inngest-brownfield-audit](./skills/inngest-brownfield-audit/)   | Audit an existing codebase for durability gaps              | Repo discovery, anti-pattern detection, incremental Inngest integration plan   |
+| [inngest-v3-v4-migration](./skills/inngest-v3-v4-migration/)     | Upgrade a codebase from SDK v3 to v4                        | Usage detection, trigger/schema/serve/realtime API changes, verification       |
 
 ## Language Support
 
@@ -84,7 +87,10 @@ skills/
 ├── inngest-realtime/
 ├── inngest-cli/
 ├── inngest-api-cli/
-└── inngest-api/
+├── inngest-api/
+├── inngest-agents/
+├── inngest-brownfield-audit/
+└── inngest-v3-v4-migration/
 ```
 
 If you're authoring or editing a skill, do it here. The plugin repo syncs from this one.

--- a/skills/inngest-agents/SKILL.md
+++ b/skills/inngest-agents/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: inngest-agents
+description: Use when building durable AI agents or agentic workflows with Inngest and AgentKit, including model calls, tool calls, multi-agent networks, human approval, realtime progress, provider rate limits, and crash-safe execution. Covers AgentKit, `step.ai`, `step.run`, `step.waitForEvent`, native realtime, and when to use lower-level Inngest primitives instead of an in-memory agent loop.
+---
+
+# Inngest Agents
+
+Use this skill when the user wants to build, migrate, or debug an AI agent,
+multi-step AI workflow, tool-calling loop, support agent, research agent,
+human-in-the-loop review flow, or realtime agent UI.
+
+Inngest's AgentKit defines agents with `createAgent`; when an AgentKit run is
+owned by an Inngest function, model calls use Inngest `step.ai` so they retry
+and cache model results durably. Use the lower-level Inngest step primitives
+around the agent for database reads/writes, tool side effects, waits,
+approvals, realtime progress, and flow control.
+
+Official references:
+
+- AgentKit agents: https://agentkit.inngest.com/concepts/agents
+- `createAgent`: https://agentkit.inngest.com/reference/create-agent
+- AI inference and `step.ai`: https://www.inngest.com/docs/features/inngest-functions/steps-workflows/step-ai-orchestration
+- AgentKit realtime hooks: https://www.inngest.com/changelog/2025-09-24-agentkit-use-agent
+
+## Copyable Example
+
+When starting a durable support or tool-calling agent from scratch, inspect the
+companion example at `../../examples/durable-agent`. It shows the expected
+agent-first shape: quick HTTP trigger, typed events, AgentKit inside an
+Inngest function, step-scoped context loading, human approval with
+`step.waitForEvent`, and durable side effects after approval.
+
+## When to Use Inngest for Agents
+
+Good fit:
+
+- Agent can take longer than one HTTP request.
+- Agent calls tools, APIs, databases, browsers, sandboxes, or MCP servers.
+- Agent needs to survive deploys, crashes, serverless timeouts, or model/API
+  failures.
+- Agent may wait for human approval, external callbacks, scheduled follow-up,
+  or user input.
+- Agent progress should stream to a UI from the durable workflow.
+- Model/provider calls need concurrency or throttle limits.
+- Duplicate sends, charges, writes, or model calls would be costly.
+
+Not usually worth it:
+
+- One short, read-only model call with no side effects and no need for durable
+  progress.
+- UI-only autocomplete where losing the request is acceptable.
+
+## Architecture
+
+Use this shape unless the repo already has a stronger established pattern:
+
+1. The HTTP/server action layer validates auth, stores the user's intent if
+   needed, emits an event with a stable `id`, and returns quickly.
+2. An Inngest function owns the agent run.
+3. Load state and external context inside `step.run`.
+4. Create AgentKit agents inside the function or import agent/network
+   factories.
+5. Run model inference through AgentKit / `step.ai`; wrap non-model tool side
+   effects in `step.run`.
+6. Use `step.waitForEvent` or `step.waitForSignal` for human approval and
+   external callbacks.
+7. Publish durable progress with native realtime.
+8. Apply flow control at the function level for provider and tenant limits.
+
+## Basic AgentKit Function
+
+Prefer a small, typed function first; add networks and extra tools after the
+single-agent path is proven.
+
+```typescript
+import { createAgent, openai } from "@inngest/agent-kit";
+import { inngest } from "@/inngest/client";
+
+export const summarizeTicket = inngest.createFunction(
+  {
+    id: "summarize-ticket",
+    triggers: [{ event: "support/ticket.created" }],
+    concurrency: [{ key: "event.data.accountId", limit: 2 }]
+  },
+  async ({ event, step }) => {
+    const ticket = await step.run("load-ticket", () => {
+      return getTicket(event.data.ticketId);
+    });
+
+    const writer = createAgent({
+      name: "support-summary-writer",
+      system: "Write a concise support-ticket summary with next actions.",
+      model: openai({ model: "gpt-4o" })
+    });
+
+    const { output } = await writer.run(JSON.stringify(ticket));
+
+    await step.run("save-summary", () => {
+      return saveTicketSummary(event.data.ticketId, output);
+    });
+
+    return { ticketId: event.data.ticketId };
+  }
+);
+```
+
+## Tool Calls
+
+Tools can be defined with AgentKit, but agent-safe tools should still follow
+durability rules:
+
+- Read-only tool calls can run as part of the agent when replaying is harmless.
+- External side effects should be isolated with stable IDs and `step.run`
+  boundaries, or implemented as tool handlers that use the provided `step`.
+- Tool outputs should be small enough for step state limits.
+- Validate tool parameters with schemas; never trust model-provided arguments.
+- Use tenant/user IDs from authenticated event data, not only from model text.
+
+Tool side-effect checklist:
+
+```text
+- What external state can this tool change?
+- What idempotency key prevents duplicate writes?
+- What should happen if the model calls the same tool twice?
+- Is the output safe to store in function run state?
+- Does the tool need provider-specific concurrency or throttle limits?
+```
+
+## Human in the Loop
+
+Use a durable wait instead of polling a database or keeping state in memory.
+
+```typescript
+const approval = await step.waitForEvent("wait-for-approval", {
+  event: "support/reply.approved",
+  timeout: "3d",
+  match: "data.ticketId"
+});
+
+if (!approval) {
+  await step.run("mark-review-timeout", () => {
+    return markTicketNeedsManualReview(event.data.ticketId);
+  });
+  return { status: "timed_out" };
+}
+
+await step.run("send-reply", () => {
+  return sendSupportReply({
+    ticketId: event.data.ticketId,
+    approvalId: approval.data.approvalId
+  });
+});
+```
+
+## Realtime Progress
+
+For v4 native realtime:
+
+- Use `step.realtime.publish` between steps.
+- Use `inngest.realtime.publish` inside an existing `step.run`.
+- Do not install the v3 `@inngest/realtime` package for v4 projects.
+- Do not build a process-local WebSocket as the only source of progress for a
+  durable function.
+
+For AgentKit-specific UI hooks, check the installed `@inngest/agent-kit`
+version and current docs before wiring `useAgent` or `useChat`.
+
+## Flow Control and Cost
+
+Agent workloads often need provider and tenant limits:
+
+- Use account-scoped concurrency or throttle keys for model providers.
+- Key per tenant or account where fairness matters.
+- Use deterministic event IDs so duplicate user actions do not spawn duplicate
+  expensive runs.
+- Keep successful model/tool results in steps so retrying a later failure does
+  not re-charge earlier model calls.
+
+Example:
+
+```typescript
+{
+  id: "support-agent-run",
+  triggers: [{ event: "support/agent.requested" }],
+  throttle: {
+    limit: 120,
+    period: "1m",
+    key: `"openai"`
+  },
+  concurrency: [
+    { key: "event.data.accountId", limit: 3 }
+  ]
+}
+```
+
+## Brownfield Migration
+
+When migrating an existing agent:
+
+1. Search for model calls, tool loops, in-memory state, streaming handlers,
+   approval polling, and external side effects.
+2. Keep prompt/tool behavior stable at first.
+3. Move the trigger into an event and an Inngest function.
+4. Move model calls to AgentKit / `step.ai`.
+5. Move side-effecting tools into `step.run` or durable tool handlers.
+6. Replace process-local waits with `step.waitForEvent` or
+   `step.waitForSignal`.
+7. Add realtime after the durable run is working.
+
+Use `inngest-brownfield-audit` first when the repo has multiple possible
+workflows and the user has not picked one.
+
+## Anti-Patterns
+
+- Agent loop state only in memory.
+- One giant `try/catch` around all model and tool calls.
+- Retrying the entire agent after one tool failure.
+- Charging repeatedly for successful model calls after a later step fails.
+- `setTimeout`, cron polling, or Redis TTL as the human-review mechanism.
+- Side-effecting tools with no idempotency key.
+- Streaming progress from a server process that can die while the durable work
+  continues elsewhere.
+- Adding AgentKit without registering the surrounding Inngest function.
+
+## Verification
+
+- Typecheck the agent, tool schemas, and event payloads.
+- Unit-test tool handlers separately from model behavior.
+- Test that the HTTP entrypoint emits one deterministic event and returns fast.
+- Test that duplicate event IDs do not duplicate final side effects.
+- If possible, run the Inngest dev server and inspect the agent steps/traces.

--- a/skills/inngest-brownfield-audit/SKILL.md
+++ b/skills/inngest-brownfield-audit/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: inngest-brownfield-audit
+description: Use when analyzing an existing TypeScript or JavaScript codebase to decide where and how to introduce Inngest. Covers repository discovery, framework and package detection, finding durability gaps in HTTP handlers, webhooks, cron jobs, queues, long-running jobs, AI agents, polling loops, and side-effect-heavy code, then producing and implementing an incremental integration plan.
+---
+
+# Inngest Brownfield Audit
+
+Use this skill when asked to inspect an existing codebase, add
+Inngest "where it makes sense", migrate fragile background work, or find
+durability gaps before making changes.
+
+This is an agent-first workflow. Do the audit from evidence in the repo, name
+the specific files and call sites that drove each conclusion, and make small
+integration moves that preserve current behavior.
+
+## When to Trigger
+
+Use this skill for requests like:
+
+- "Audit this repo for Inngest opportunities"
+- "Add Inngest to this codebase"
+- "Make our webhooks / cron jobs / background tasks reliable"
+- "Find places where work can be lost on deploy or process crash"
+- "Replace fragile polling, delayed jobs, or fire-and-forget promises"
+- "Make this AI workflow / agent durable"
+
+If the user is starting from scratch instead of a brownfield repo, use
+`inngest-setup`, `inngest-durable-functions`, `inngest-events`,
+`inngest-steps`, and, for AI workflows, the agent patterns in this skill.
+
+## Audit Loop
+
+1. **Map the project shape.**
+   - Read `package.json`, workspace files, app/router structure, server entry
+     points, deployment config, and test scripts.
+   - Identify framework: Next.js App Router, Next.js Pages Router, Express,
+     Hono, Fastify, Remix, SvelteKit, Astro, NestJS, worker-only service, or
+     other.
+   - Detect package manager and TypeScript conventions before adding files.
+
+2. **Find existing Inngest usage.**
+   - Search for `inngest`, `createFunction`, `serve(`, `/api/inngest`,
+     `INNGEST_`, `step.run`, `step.sleep`, `step.waitForEvent`,
+     `step.sendEvent`, `step.invoke`, `step.ai`, `inngest.send`, and
+     `@inngest/realtime`.
+   - If Inngest exists, inspect version, client config, serve endpoint,
+     registered functions, event naming, env vars, and v3/v4 API shape before
+     changing anything.
+
+3. **Find durability gaps.**
+   - Search for fire-and-forget work: `void someAsync()`, un-awaited promises,
+     `.then(` chains, `setTimeout`, `setInterval`, detached jobs after HTTP
+     response, and background work in route handlers.
+   - Search for cron and schedulers: `cron`, `node-cron`, `agenda`, `bull`,
+     `bullmq`, `bee-queue`, `qstash`, `sqs`, `temporal`, `trigger.dev`,
+     deployment cron config, and scheduled API routes.
+   - Search for webhooks and at-least-once producers: Stripe, Clerk, GitHub,
+     Slack, Shopify, HubSpot, Linear, Svix, and generic `webhook`.
+   - Search for long-running work: PDF generation, exports, video/image
+     processing, embeddings, bulk email, imports, ETL, sync jobs, polling loops,
+     retries, and external API calls.
+   - Search for AI agent shapes: tool loops, LLM calls, streaming tokens,
+     human approval, multi-step reasoning, vector search, eval loops, and
+     provider calls that need rate limits or retry-safe state.
+
+4. **Classify each candidate.**
+   - **P0:** user-visible loss, duplicate charge/email/action, timeout, missed
+     webhook, or crash-prone workflow.
+   - **P1:** fragile but recoverable background work, manual retry burden,
+     noisy 429s, or poor observability.
+   - **P2:** cleanup, ergonomics, or future migration opportunity.
+   - For each candidate, record: file, current trigger, side effects,
+     idempotency key, failure mode, recommended Inngest primitive, migration
+     size, and confidence.
+
+5. **Choose the smallest safe integration.**
+   - Prefer one vertical slice over a wide rewrite.
+   - Keep existing domain functions and data models where possible.
+   - Add an Inngest client and serve endpoint only once.
+   - Move side effects into `step.run` one boundary at a time.
+   - Make event IDs and database writes idempotent before adding retries.
+   - Add tests around existing behavior and the new event/function boundary.
+
+## Useful Discovery Commands
+
+Run commands that fit the repo. Prefer `rg`; keep output focused.
+
+```bash
+rg -n "inngest|createFunction|step\\.|serve\\(|/api/inngest|INNGEST_" .
+rg -n "setTimeout|setInterval|Promise\\.all|void [a-zA-Z0-9_]+\\(|\\.then\\(" .
+rg -n "cron|node-cron|schedule|bull|bullmq|bee-queue|agenda|qstash|sqs" .
+rg -n "webhook|stripe|svix|clerk|github|shopify|slack|hubspot|linear" .
+rg -n "retry|backoff|poll|status|timeout|429|rate limit|rate-limit" .
+rg -n "openai|anthropic|ai\\.|generateText|streamText|tool|agent|embedding" .
+```
+
+When the repo is large, narrow searches to app source directories and exclude
+generated/vendor folders.
+
+## Brownfield Decision Matrix
+
+| Existing shape | Inngest fit | Primary primitives |
+|---|---|---|
+| HTTP handler does slow side effects before responding | Emit event, return fast | `inngest.send`, event trigger, `step.run` |
+| Webhook must acknowledge quickly but process reliably | Verify signature, emit idempotent event | Event ID, `step.run`, retries |
+| Cron job loses progress midway | Cron-triggered durable function | Cron trigger, page-level `step.run`, flow control |
+| Polling loop waits for external async work | Durable wait or durable poll | `step.waitForEvent`, `step.sleep`, `step.run` |
+| Large fan-out exceeds request/serverless limits | Split orchestration and item work | `step.sendEvent`, per-item function, concurrency |
+| External API hits 429s | Move limits to function config | `throttle`, `rateLimit`, `concurrency` |
+| Human review can take days | Persist the wait in Inngest | `step.waitForEvent`, timeout, realtime |
+| AI agent/tool loop needs retry-safe progress | One step per tool/model boundary | `step.ai`, `step.run`, `step.sleep`, realtime |
+| Existing queue only hides fragile work | Replace queue boundary gradually | Event trigger, idempotency, function-level retries |
+
+## Integration Plan Format
+
+Before editing, summarize findings in this compact shape:
+
+```text
+Inngest audit:
+- Existing Inngest: none / partial / healthy / risky
+- Framework: <framework and evidence>
+- Best first slice: <file + workflow>
+- Why: <loss/timeout/retry/idempotency failure>
+- Proposed primitives: <event, steps, flow control, waits, realtime>
+- Idempotency key: <source of truth>
+- Files likely touched: <short list>
+- Tests/checks: <commands or focused cases>
+```
+
+Then implement unless the user asked for audit-only.
+
+## Existing Inngest Checklist
+
+If Inngest is already present, verify:
+
+- A single shared client is exported from a stable module.
+- The app `id` is a stable slug and is not derived from deploy-specific data.
+- v4 local development uses `INNGEST_DEV=1`; production uses
+  `INNGEST_SIGNING_KEY`.
+- Serve endpoint path is discoverable, usually `/api/inngest`.
+- The serve handler registers all functions that should sync.
+- Side effects and non-deterministic work are inside steps.
+- Step IDs are stable and descriptive.
+- Event names follow `domain/noun.verb`.
+- Events that may be replayed use deterministic IDs.
+- Webhook handlers verify signatures before emitting events.
+- Flow control is configured where external APIs have limits.
+- Realtime uses v4 native `inngest/realtime`, not the v3
+  `@inngest/realtime` package.
+
+## Durable Agent Patterns
+
+Use Inngest when an AI or agent workflow needs durable progress across model
+calls, tool calls, waits, approvals, or streaming UI updates.
+
+Good candidates:
+
+- Multi-step agent that calls tools or external APIs.
+- LLM workflow that may exceed one HTTP request lifetime.
+- Human-in-the-loop review, approval, correction, or escalation.
+- Agent that must pause for an external event or scheduled follow-up.
+- Bulk AI work that needs provider-level rate limits and cost protection.
+- User-visible agent progress that should stream from durable execution.
+
+Recommended shape:
+
+1. HTTP/UI request stores the user intent and emits an event with a stable
+   `id`.
+2. Inngest function loads state inside `step.run`.
+3. Each model call, tool call, vector search, and external side effect lives in
+   its own `step.ai` or `step.run` boundary.
+4. Human pauses use `step.waitForEvent` or `step.waitForSignal` with a timeout.
+5. Progress updates use `step.realtime.publish` between steps, or
+   `inngest.realtime.publish` inside an existing `step.run`.
+6. Provider rate limits use `concurrency`, `throttle`, or `rateLimit`, not
+   ad hoc in-process throttlers.
+
+Avoid:
+
+- Keeping agent state only in memory.
+- Retrying whole agent loops after a single tool failure.
+- Charging for repeated successful model calls because the result was not
+  memoized.
+- Using `setTimeout` or a cron poller for follow-ups and approvals.
+- Streaming progress from a process-local WebSocket server when the workflow
+  itself is durable elsewhere.
+
+## Implementation Guardrails
+
+- Do not replace working queues, crons, or webhooks blindly. First preserve
+  behavior with a thin Inngest slice.
+- Do not create duplicate clients or serve endpoints if the repo already has
+  them.
+- Do not put database writes, API calls, random IDs, timestamps, or LLM calls
+  outside steps in the new function.
+- Do not hide missing idempotency behind retries. Retries require idempotent
+  side effects.
+- Do not hardcode secrets or dev-mode flags in source.
+- Do not leave the app unable to sync: register new functions with the serve
+  endpoint and run available type/tests.
+
+## Verification
+
+Pick checks that prove the integration path:
+
+- Typecheck/build/lint the touched app.
+- Run existing tests around the migrated handler or workflow.
+- Add focused tests for "handler emits event and returns fast" and "function
+  calls the same domain operations in step boundaries" where the repo supports
+  it.
+- If local runtime is available, start the app and Inngest dev server, confirm
+  the function syncs, then send a sample event.
+- If only static checks are available, explicitly state that runtime sync was
+  not verified.

--- a/skills/inngest-v3-v4-migration/SKILL.md
+++ b/skills/inngest-v3-v4-migration/SKILL.md
@@ -1,0 +1,331 @@
+---
+name: inngest-v3-v4-migration
+description: Use when upgrading an existing TypeScript codebase from Inngest SDK v3 to v4, or when fixing mixed v3/v4 API usage. Covers detecting current SDK usage, moving triggers into createFunction options, replacing EventSchemas with eventType/staticSchema, moving serve options to the client, updating realtime imports, rewriting step.invoke string IDs, checkpointing/serverless runtime settings, Connect option changes, and verification.
+---
+
+# Inngest v3 to v4 Migration
+
+Use this skill when the user asks to upgrade Inngest, fix v3/v4 errors, migrate
+realtime, or clean up a codebase that has mixed SDK patterns.
+
+Primary reference:
+https://www.inngest.com/docs/reference/typescript/v4/migrations/v3-to-v4
+
+This skill is agent-first: detect actual usage first, make mechanical API
+changes in a controlled order, then typecheck and run focused tests.
+
+## When to Trigger
+
+Use this skill for requests like:
+
+- "Upgrade Inngest from v3 to v4"
+- "Fix our Inngest v4 migration"
+- "We're getting signing key required / cloud mode errors after upgrading"
+- "`step.invoke` with a string function ID stopped working"
+- "`@inngest/realtime` broke after installing `inngest@4`"
+- "Move from EventSchemas to eventType"
+- "Make this existing Inngest repo v4-compatible"
+
+If the user asks for a broad codebase reliability audit first, use
+`inngest-brownfield-audit` to choose scope, then return here for the v4 changes.
+
+## Migration Scan
+
+Start by locating all Inngest surfaces:
+
+```bash
+rg -n '"inngest"|"@inngest/realtime"|"@inngest/agent-kit"' package.json **/package.json
+rg -n 'new Inngest|EventSchemas|eventType|staticSchema|createFunction\\(|serve\\(|connect\\(|step\\.invoke|referenceFunction|@inngest/realtime|realtimeMiddleware|useInngestSubscription|serveHost|rewriteGatewayEndpoint|logLevel|streaming:|signingKey|signingKeyFallback|baseUrl|INNGEST_DEV|INNGEST_SIGNING_KEY' .
+```
+
+Then classify the repo:
+
+- **No Inngest yet:** use `inngest-setup`, not this migration skill.
+- **v3 only:** migrate the SDK and all breaking changes together.
+- **mixed v3/v4:** prioritize removing broken v3 APIs from v4 code.
+- **v4 mostly done:** focus on missed runtime gotchas like local dev mode,
+  serverless `maxRuntime`, realtime package imports, and string `step.invoke`.
+
+Before editing, record:
+
+```text
+Inngest migration scan:
+- Current package versions:
+- Client files:
+- Serve/connect entrypoints:
+- Functions using old trigger syntax:
+- EventSchemas usage:
+- Realtime v3 package usage:
+- step.invoke string IDs:
+- Serverless runtime constraints:
+- Tests/checks available:
+```
+
+## Upgrade Order
+
+1. Update package versions.
+2. Fix client construction and local/prod mode.
+3. Move serve options to the client.
+4. Move triggers into `createFunction` options.
+5. Replace `EventSchemas` with `eventType()` / `staticSchema()`.
+6. Rewrite `step.invoke()` string IDs.
+7. Migrate realtime from `@inngest/realtime` to v4 native APIs.
+8. Update middleware and logging.
+9. Configure checkpointing/serverless runtime.
+10. Typecheck, run tests, and optionally sync with the dev server.
+
+## Package and Environment
+
+Install the latest v4 SDK:
+
+```bash
+npm install inngest@latest
+# or pnpm add inngest@latest
+# or yarn add inngest@latest
+```
+
+If the repo uses v3 realtime, remove `@inngest/realtime`; v4 realtime lives in
+the `inngest` package and subpaths such as `inngest/realtime`, `inngest/react`,
+and native `step.realtime` / `inngest.realtime`.
+
+v4 defaults to Cloud mode. For local development, use an env var:
+
+```bash
+INNGEST_DEV=1 npm run dev
+```
+
+Do not hardcode `isDev: true` in source unless the repo's existing environment
+pattern clearly scopes it to local-only code. Production should use
+`INNGEST_SIGNING_KEY`.
+
+## Client and Serve Options
+
+In v4, options such as `signingKey`, `signingKeyFallback`, and `baseUrl` belong
+on `new Inngest(...)`, not on `serve(...)`.
+
+```typescript
+// Old v3
+app.use(
+  "/api/inngest",
+  serve({
+    client: inngest,
+    functions,
+    signingKey: process.env.INNGEST_SIGNING_KEY,
+    baseUrl: process.env.INNGEST_BASE_URL,
+  })
+);
+
+// New v4
+export const inngest = new Inngest({
+  id: "my-app",
+  signingKey: process.env.INNGEST_SIGNING_KEY,
+  baseUrl: process.env.INNGEST_BASE_URL,
+});
+
+app.use("/api/inngest", serve({ client: inngest, functions }));
+```
+
+If the repo already relies on supported environment variables and does not pass
+serve options explicitly, no code change may be required for those keys.
+
+Other renames:
+
+- `serveHost` -> `serveOrigin`
+- `streaming: "force"` -> `streaming: true`
+- `streaming: "allow"` -> `streaming: true`
+- `streaming: false` stays `false`
+- `logLevel` is removed; pass a `logger` such as `new ConsoleLogger({ level })`
+
+## createFunction Triggers
+
+Triggers move into the first argument's options object.
+
+```typescript
+// Old v3
+inngest.createFunction(
+  { id: "send-welcome" },
+  { event: "user/created" },
+  async ({ event, step }) => {}
+);
+
+// New v4
+inngest.createFunction(
+  { id: "send-welcome", triggers: [{ event: "user/created" }] },
+  async ({ event, step }) => {}
+);
+```
+
+Cron triggers move the same way:
+
+```typescript
+inngest.createFunction(
+  { id: "nightly-sync", triggers: [{ cron: "0 2 * * *" }] },
+  async ({ step }) => {}
+);
+```
+
+If a function is invoked only via `step.invoke`, it may be triggerless.
+
+## EventSchemas to eventType/staticSchema
+
+Replace centralized `EventSchemas` with event-specific definitions.
+
+```typescript
+import { Inngest, eventType, staticSchema } from "inngest";
+import { z } from "zod";
+
+export const userCreated = eventType("user/created", {
+  schema: z.object({
+    userId: z.string(),
+    email: z.string().email(),
+  }),
+});
+
+type InvoicePaid = {
+  invoiceId: string;
+  customerId: string;
+};
+
+export const invoicePaid = eventType("billing/invoice.paid", {
+  schema: staticSchema<InvoicePaid>(),
+});
+```
+
+Use event types consistently:
+
+```typescript
+await inngest.send(userCreated.create({ userId, email }));
+
+inngest.createFunction(
+  { id: "on-user-created", triggers: [userCreated] },
+  async ({ event }) => {}
+);
+
+await step.waitForEvent("wait-for-invoice", {
+  event: invoicePaid,
+  timeout: "7d",
+});
+```
+
+Important: `staticSchema` expects a type, not an interface. Convert interfaces
+to type aliases when needed.
+
+## step.invoke
+
+v4 no longer accepts raw string function IDs. Use an imported function
+reference or `referenceFunction()`.
+
+```typescript
+import { referenceFunction } from "inngest";
+
+await step.invoke("run-report", {
+  function: referenceFunction({
+    appId: "analytics-app",
+    functionId: "generate-report",
+  }),
+  data: { reportId },
+});
+```
+
+If the target function is in the same codebase, prefer passing the imported
+function itself:
+
+```typescript
+await step.invoke("run-report", {
+  function: generateReport,
+  data: { reportId },
+});
+```
+
+## Realtime Migration
+
+v3 realtime used `@inngest/realtime` and middleware-injected `publish`.
+v4 realtime is native.
+
+Replace:
+
+- `@inngest/realtime` package
+- `realtimeMiddleware()`
+- handler args such as `{ publish }`
+- v3 React hooks such as `useInngestSubscription()`
+
+With:
+
+- channel definitions from `inngest/realtime`
+- `step.realtime.publish` between steps
+- `inngest.realtime.publish` inside an existing `step.run`
+- subscription helpers/hooks from current v4 APIs
+
+Use `inngest-realtime` for detailed patterns. Do not call
+`step.realtime.publish` from inside `step.run`; use `inngest.realtime.publish`
+there to avoid step-in-step behavior.
+
+## Parallelism and Checkpointing
+
+v4 enables optimized parallelism and checkpointing by default.
+
+Watch for `Promise.race` over steps. With optimized parallelism, `Promise.race`
+waits for all step promises to settle. If the repo relies on first-winner
+behavior, use `group.parallel()`.
+
+For serverless platforms, configure checkpointing `maxRuntime` slightly below
+the platform limit:
+
+```typescript
+export const inngest = new Inngest({
+  id: "my-app",
+  checkpointing: {
+    maxRuntime: "50s",
+  },
+});
+```
+
+On Vercel or similar frameworks, also set the route handler's max duration
+where the platform supports it.
+
+## Connect Changes
+
+If the repo uses Connect:
+
+- `rewriteGatewayEndpoint` is replaced by `gatewayUrl`.
+- Connect may use worker-thread isolation. If integration issues appear, check
+  `isolateExecution: false` or `INNGEST_CONNECT_ISOLATE_EXECUTION=false`.
+- Keep target URLs and signing/event keys in env vars.
+
+## Verification
+
+Run checks in increasing confidence:
+
+1. Package manager install/update.
+2. Typecheck.
+3. Unit/integration tests around migrated functions.
+4. Start the app with `INNGEST_DEV=1`.
+5. Run `npx inngest-cli@latest dev` and confirm function discovery.
+6. Send one representative event and inspect the run.
+
+If local dev-server verification is not possible, state exactly which static
+checks passed and what runtime verification remains.
+
+## Common Failure Messages
+
+- **"A signing key is required to run in Cloud mode"**: set `INNGEST_DEV=1` for
+  local development or configure `INNGEST_SIGNING_KEY` for production.
+- **`Cls is not a constructor` on `/api/inngest`**: likely v3
+  `@inngest/realtime` middleware in a v4 app. Remove the package and migrate to
+  native realtime.
+- **`step.invoke` fails with string function ID**: replace strings with
+  imported function references or `referenceFunction()`.
+- **Type errors around schemas**: replace `EventSchemas` with `eventType()` and
+  `staticSchema()`.
+- **Unexpected `Promise.race` behavior**: use `group.parallel()` for first-winner
+  step races or disable optimized parallelism only when necessary.
+
+## Anti-Patterns
+
+- Mixing v3 realtime middleware with `inngest@4`.
+- Passing `signingKey`, `baseUrl`, or `signingKeyFallback` to `serve()`.
+- Moving event trigger syntax but forgetting cron/invoke-triggered functions.
+- Replacing `EventSchemas` with untyped string events everywhere.
+- Hardcoding `isDev: true` in production-bound source.
+- Leaving string IDs in `step.invoke`.
+- Skipping typecheck after mechanical migration.


### PR DESCRIPTION
## What

Upstreams three skills that were authored in [inngest/inngest-codex-plugin](https://github.com/inngest/inngest-codex-plugin) (v0.3) into this repo, which is the source of truth for skills:

- **`inngest-agents`** — durable AI agents and agentic workflows: AgentKit, `step.ai`, tool calls, multi-agent networks, human approval, realtime progress.
- **`inngest-brownfield-audit`** — analyze an existing TS/JS codebase for durability gaps (polling loops, manual retries, fire-and-forget promises, queue libraries) and produce an incremental Inngest integration plan.
- **`inngest-v3-v4-migration`** — upgrade a codebase from SDK v3 to v4: usage detection, trigger/schema/serve/realtime API changes, verification.

Copied verbatim except one Codex-specific phrase neutralized in `inngest-brownfield-audit` ("when the user asks Codex to inspect" → "when asked to inspect"). README table and repo-layout tree updated.

## Why

Per the repo convention, skills are authored here and plugins sync from this repo. These three existed only in the codex plugin, so the Claude Code plugin (and skills.sh users) couldn't get them. Companion PR on inngest/inngest-claude-code-plugin syncs them into the Claude Code plugin and updates its roadmap (which still listed v3→v4 migration and brownfield audit as future work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)