### PR TITLE
[codex] Add Agent Evals skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Inngest Agent Skills
 
-Agent Skills for building with [Inngest](https://www.inngest.com)'s durable execution platform. These skills give AI coding agents comprehensive guidance on creating reliable, fault-tolerant applications: durable functions, events, steps, flow control, middleware, realtime, AI agents, CLI operations, REST API fallback, brownfield audits, and SDK migrations.
+Agent Skills for building with [Inngest](https://www.inngest.com)'s durable execution platform. These skills give AI coding agents comprehensive guidance on creating reliable, fault-tolerant applications: durable functions, events, steps, flow control, middleware, realtime, AI agents, Agent Evals, CLI operations, REST API fallback, brownfield audits, and SDK migrations.
 
 > **Looking for the full agent-plugin experience?** Use the [Inngest plugin for Claude Code](https://github.com/inngest/inngest-claude-code-plugin) or the [Inngest plugin for Codex](https://github.com/inngest/inngest-codex-plugin) — same shared skills, plus plugin-specific MCP, eval harnesses, commands, or agents.
 
@@ -28,6 +28,7 @@ Learn more about [Agent Skills](https://agentskills.io).
 | [inngest-api-cli](./skills/inngest-api-cli/)                     | Operate Inngest API resources from the terminal             | `inngest api`, Cloud debugging, traces, event runs, invocation, Insights       |
 | [inngest-api](./skills/inngest-api/)                             | Use REST API v2 and OpenAPI fallback                        | Raw HTTP, API keys, docs lookup, request shapes, pagination, secret redaction  |
 | [inngest-agents](./skills/inngest-agents/)                       | Build durable AI agents and agentic workflows               | AgentKit, `step.ai`, tool calls, multi-agent networks, human approval, realtime |
+| [inngest-agent-evals](./skills/inngest-agent-evals/)             | Evaluate AI agents and workflows in production              | Scoring, deferred scorers, sessions, traces, step experiments, Insights        |
 | [inngest-brownfield-audit](./skills/inngest-brownfield-audit/)   | Audit an existing codebase for durability gaps              | Repo discovery, anti-pattern detection, incremental Inngest integration plan   |
 | [inngest-v3-v4-migration](./skills/inngest-v3-v4-migration/)     | Upgrade a codebase from SDK v3 to v4                        | Usage detection, trigger/schema/serve/realtime API changes, verification       |
 
@@ -89,6 +90,7 @@ skills/
 ├── inngest-api-cli/
 ├── inngest-api/
 ├── inngest-agents/
+├── inngest-agent-evals/
 ├── inngest-brownfield-audit/
 └── inngest-v3-v4-migration/
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,10 +6,11 @@ inventory.
 
 ---
 
-## Today (v0.1.0)
+## Today (v0.3.0)
 
-The first release covers the core surface for TypeScript projects
-building durable systems with Inngest:
+The current shared skills cover the core surface for TypeScript projects
+building durable systems, durable AI agents, Agent Evals, and brownfield
+Inngest migrations:
 
 | Skill | What it covers |
 |---|---|
@@ -23,6 +24,10 @@ building durable systems with Inngest:
 | `inngest-cli` | General CLI and dev server workflows: install/run `inngest dev`, local testing, Docker, MCP setup, deployment checks, and self-hosted `inngest start` |
 | `inngest-api-cli` | Prescriptive terminal workflows for `inngest api`, Cloud debugging, run traces, event runs, app syncs, invocation, webhooks, envs, keys, and Insights |
 | `inngest-api` | REST API v2 and OpenAPI fallback when raw HTTP is needed or the CLI does not expose an endpoint |
+| `inngest-agents` | AgentKit, `step.ai`, tool calls, human review, realtime progress, provider flow control |
+| `inngest-agent-evals` | Scoring, deferred scorers, sessions, traces, step experiments, Insights, outcome-based eval loops |
+| `inngest-brownfield-audit` | Repository analysis, durability-gap discovery, incremental integration planning |
+| `inngest-v3-v4-migration` | TypeScript SDK v3 to v4 migration, mixed API cleanup, realtime migration |
 
 Plugin bundles can also ship local dev server MCP config (`.mcp.json`) so
 Claude Code, Codex, or other MCP-capable agents can interact with the Inngest
@@ -129,3 +134,6 @@ Releases are tagged in this repo.
 - **v0.2.0** — adds `inngest-cli` for general CLI/dev-server workflows,
   `inngest-api-cli` for prescriptive `inngest api` operations, and narrows
   `inngest-api` to REST API v2/OpenAPI fallback.
+- **v0.3.0** — adds `inngest-agent-evals` for Agent Evals with scoring,
+  deferred scorers, sessions, traces, step experiments, Insights, and
+  outcome-based evaluation loops.

--- a/skills/inngest-agent-evals/SKILL.md
+++ b/skills/inngest-agent-evals/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: inngest-agent-evals
+description: "Use when building, migrating, or debugging Agent Evals on Inngest: scoring AI agent or workflow outcomes, deferred scorers, sessions, traces, step experiments, experiment variant attribution, Insights queries, or production eval loops for prompts, models, tools, providers, and agent behavior. Covers TypeScript SDK v4 scoring beta APIs, `scoreMiddleware`, `step.score`, `inngest.score`, `createScorer`, `defer`, `group.experiment`, `experimentRef`, `meta.sessions`, and when to use durable workflow primitives for outcome-based evaluation."
+---
+
+# Inngest Agent Evals
+
+Use this skill when the user wants to evaluate AI agents or AI workflows in
+production, add scoring, compare prompts/models/tools, group related runs, or
+debug why an agent outcome was good or bad.
+
+Agent Evals is not a separate package. It is the production evaluation workflow
+built from Inngest functions, durable steps, scores, deferred scorers, sessions,
+traces, experiments, and Insights.
+
+## Canonical References
+
+Check the public docs first when exact API details matter:
+
+- Agent Evals overview: https://www.inngest.com/docs/learn/agent-evals
+- Scoring guide: https://www.inngest.com/docs/features/inngest-functions/steps-workflows/scoring
+- Deferred scoring guide: https://www.inngest.com/docs/features/inngest-functions/steps-workflows/deferred-scoring
+- Step experiments guide: https://www.inngest.com/docs/features/inngest-functions/steps-workflows/step-experiments
+- Sessions: https://www.inngest.com/docs/features/events-triggers/sessions
+- Traces: https://www.inngest.com/docs/platform/monitor/traces
+- Insights: https://www.inngest.com/docs/platform/monitor/insights
+- Scoring reference: https://www.inngest.com/docs/reference/typescript/v4/functions/scoring
+- `group.experiment()` reference: https://www.inngest.com/docs/reference/typescript/v4/functions/group-experiment
+- Launch context: https://www.inngest.com/blog/introducing-agent-evals
+
+## Decision Flow
+
+Start from the outcome, not the mechanism:
+
+1. Identify the product or quality signal: helpful click, ticket resolution,
+   conversion, guardrail pass, retrieval quality, model confidence, latency,
+   cost, human review, or LLM-as-judge result.
+2. Decide when the signal appears:
+   - During the run: use direct scoring with `step.score()` or
+     `inngest.score()`.
+   - After the run: use deferred scoring with `createScorer()` and `defer()`,
+     or explicit `inngest.score({ runId })`.
+3. Decide how humans will inspect related work:
+   - Use `meta.sessions` for repeated high-cardinality identifiers such as
+     `conversation_id`, `ticket_id`, `agent_run_id`, or `import_id`.
+   - Use Insights for ad hoc historical analysis, low-cardinality filters, SQL
+     aggregates, and broad investigation.
+4. Decide whether to compare variants:
+   - Use `group.experiment()` for prompt, model, provider, tool, workflow, or
+     rollout comparisons.
+   - Pass `experimentRef` to deferred or later scores when the score should be
+     credited to the selected variant.
+5. Preserve traceability:
+   - Keep model calls, tool calls, waits, database writes, and scoring work in
+     durable steps so traces explain why the score happened.
+
+## Setup Requirements
+
+- Use TypeScript SDK v4 and install the latest SDK: `npm install inngest@latest`.
+- Scoring and deferred scoring are beta APIs; verify current imports against
+  the docs before shipping user-facing examples.
+- `step.score()` requires `scoreMiddleware()` from `inngest/experimental` on
+  the Inngest client.
+- `createScorer()` is imported from `inngest/experimental` and the scorer must
+  be registered in the serve handler with other functions.
+- Sessions sent through the TypeScript SDK require v4.7.0 or later.
+- Step experiments require v4.8.0 or later for `group.experiment()` and the
+  `experiment` helper from `inngest`.
+
+Client shape:
+
+```typescript
+import { Inngest } from "inngest";
+import { scoreMiddleware } from "inngest/experimental";
+
+export const inngest = new Inngest({
+  id: "support-agent",
+  middleware: [scoreMiddleware()],
+});
+```
+
+## Sessions
+
+Add sessions when events belong to a user flow, conversation, ticket, import,
+or agent task that someone will inspect repeatedly.
+
+```typescript
+await inngest.send({
+  name: "support/ticket.created",
+  data: {
+    ticketId: "tk_123",
+    message: "I can't sign in.",
+  },
+  meta: {
+    sessions: {
+      ticket_id: "tk_123",
+    },
+  },
+});
+```
+
+Rules:
+
+- Use stable, non-secret, high-cardinality IDs.
+- Keep the key generic, such as `conversation_id`; put the actual ID in the
+  value.
+- Pass sessions explicitly through `step.invoke()` and `step.sendEvent()` when
+  downstream runs should join the same session.
+- Do not use sessions for labels like `environment: prod`; use Insights for
+  that style of filtering.
+
+## Direct Scoring
+
+Use direct scoring when the score is known during the function run.
+
+Good direct scores:
+
+- guardrail pass/fail
+- JSON validity
+- retrieval confidence
+- tool success
+- model confidence
+- inline LLM-as-judge result
+
+```typescript
+export const answerTicket = inngest.createFunction(
+  {
+    id: "answer-ticket",
+    triggers: [{ event: "support/ticket.created" }],
+  },
+  async ({ event, step }) => {
+    const answer = await step.run("generate-answer", () =>
+      generateAnswer(event.data.ticketId)
+    );
+
+    const passed = await step.run("check-answer", () => validateAnswer(answer));
+
+    await step.score("score-answer-quality", {
+      name: "answer-quality",
+      value: passed,
+    });
+
+    return { answer, passed };
+  }
+);
+```
+
+Use stable score names. Changing a score name creates a separate metric.
+Score values must be finite numbers or booleans.
+
+## Deferred Scoring
+
+Use deferred scoring when the useful signal arrives after the parent workflow
+finishes, such as user feedback, conversion, ticket reopen, retention, or a
+slow LLM-as-judge run.
+
+```typescript
+import { createScorer } from "inngest/experimental";
+import { z } from "zod";
+
+export const feedbackScorer = createScorer(
+  inngest,
+  {
+    id: "support-feedback-scorer",
+    schema: z.object({ ticketId: z.string() }),
+  },
+  async ({ event, step }) => {
+    const feedback = await step.waitForEvent("wait-for-feedback", {
+      event: "support/feedback.received",
+      timeout: "7d",
+      if: `async.data.ticketId == '${event.data.ticketId}'`,
+    });
+
+    return {
+      name: "user-feedback",
+      value: feedback?.data.helpful ? 1 : 0,
+    };
+  }
+);
+```
+
+Trigger it from the producing function:
+
+```typescript
+async ({ event, step, defer }) => {
+  const answer = await step.run("generate-answer", () =>
+    generateAnswer(event.data.ticketId)
+  );
+
+  defer("score-feedback", {
+    function: feedbackScorer,
+    data: { ticketId: event.data.ticketId },
+  });
+
+  return { answer };
+}
+```
+
+Guardrails:
+
+- Register scorers with `serve({ functions: [...] })`.
+- `defer()` is fire-and-forget; do not `await` it.
+- The parent run is attributed automatically for deferred scorers.
+- Return a default score or `null` when a signal times out, based on the
+  product semantics.
+
+## Experiments
+
+Use `group.experiment()` when comparing prompts, models, providers, tools,
+workflow rewrites, or operational settings against real traffic.
+
+```typescript
+import { experiment } from "inngest";
+
+const { result, variant, experimentRef } = await group.experiment(
+  "answer-style",
+  {
+    variants: {
+      concise: () => step.run("answer-concise", () => answerConcise(event.data)),
+      detailed: () =>
+        step.run("answer-detailed", () => answerDetailed(event.data)),
+    },
+    select: experiment.bucket(event.data.accountId, {
+      weights: { concise: 50, detailed: 50 },
+    }),
+  }
+);
+```
+
+Selection strategy:
+
+- `experiment.weighted()` for run-level traffic splits.
+- `experiment.bucket(stableId, { weights })` when a user, account, or tenant
+  should usually keep the same experience.
+- `experiment.custom()` when assignment comes from a database, flag service, or
+  rollout table.
+- `experiment.fixed()` to force one variant during testing or after choosing a
+  winner.
+
+Rules:
+
+- Each variant callback must call at least one `step.*` tool.
+- Keep experiment IDs and variant names stable because they appear in traces.
+- The selected variant is memoized for retries and replays.
+- Persist `experimentRef` and the parent run ID if a later, separate process
+  will score the selected variant.
+
+When deferred scoring a variant, pass the ref:
+
+```typescript
+defer("score-answer-feedback", {
+  function: feedbackScorer,
+  data: { ticketId: event.data.ticketId },
+  experiment: experimentRef,
+});
+```
+
+When scoring from a later run explicitly:
+
+```typescript
+await inngest.score.experiment({
+  name: "clickthrough",
+  value: 1,
+  experiment: experimentRef,
+  runId: originalRunId,
+});
+```
+
+## Brownfield Migration
+
+When adding Agent Evals to an existing app:
+
+1. Search for existing agent/workflow outputs and where users act on them.
+2. Find durable identifiers already in the domain: conversation ID, ticket ID,
+   account ID, import ID, run ID, or recommendation ID.
+3. Add `meta.sessions` at event producers before building dashboards around
+   correlation.
+4. Add one direct score where the outcome is already known.
+5. Add a deferred scorer only after the signal event exists or can be emitted
+   cleanly.
+6. Add `group.experiment()` only around one isolated decision at a time.
+7. Keep old prompt/model/tool behavior stable until scoring proves the new path.
+
+Use `inngest-brownfield-audit` first when the repo has many candidate
+workflows. Use `inngest-agents` with this skill when the work is an AgentKit or
+durable agent workflow.
+
+## Anti-Patterns
+
+- Starting with a prompt experiment before naming the outcome metric.
+- Scoring with unstable names, strings, objects, `NaN`, or `Infinity`.
+- Forgetting `scoreMiddleware()` and then assuming `step.score()` is missing.
+- Running scorers in an external queue when the scorer needs durable waits.
+- Keeping experiment assignment only in memory.
+- Scoring an experiment variant from a later run without the original `runId`.
+- Using sessions for low-cardinality labels or sensitive personal data.
+- Leaving model/tool work outside steps, making traces unable to explain the
+  score.
+
+## Verification
+
+- Typecheck the Inngest client, functions, scorer schemas, and serve handler.
+- Confirm scorers are registered with the serve endpoint.
+- Test the producer emits events with expected `meta.sessions`.
+- Test direct scores use stable names and finite number/boolean values.
+- Test deferred scorer timeout behavior.
+- For experiments, test that each variant callback contains step work and that
+  later scoring receives `experimentRef` plus the original run ID when needed.
+- If possible, run the Inngest dev server and inspect traces, sessions, scores,
+  and experiment variant selection in the dashboard or through available CLI/API
+  tooling.

--- a/skills/inngest-agents/SKILL.md
+++ b/skills/inngest-agents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inngest-agents
-description: Use when building durable AI agents or agentic workflows with Inngest and AgentKit, including model calls, tool calls, multi-agent networks, human approval, realtime progress, provider rate limits, and crash-safe execution. Covers AgentKit, `step.ai`, `step.run`, `step.waitForEvent`, native realtime, and when to use lower-level Inngest primitives instead of an in-memory agent loop.
+description: Use when building durable AI agents or agentic workflows with Inngest and AgentKit, including model calls, tool calls, multi-agent networks, human approval, realtime progress, provider rate limits, crash-safe execution, and Agent Evals handoff. Covers AgentKit, `step.ai`, `step.run`, `step.waitForEvent`, native realtime, and when to use lower-level Inngest primitives instead of an in-memory agent loop. Use `inngest-agent-evals` with this skill when the user wants scoring, sessions, experiments, deferred scorers, or outcome-based evaluation for the agent.
 ---
 
 # Inngest Agents
@@ -20,6 +20,7 @@ Official references:
 - AgentKit agents: https://agentkit.inngest.com/concepts/agents
 - `createAgent`: https://agentkit.inngest.com/reference/create-agent
 - AI inference and `step.ai`: https://www.inngest.com/docs/features/inngest-functions/steps-workflows/step-ai-orchestration
+- Agent Evals: https://www.inngest.com/docs/learn/agent-evals
 - AgentKit realtime hooks: https://www.inngest.com/changelog/2025-09-24-agentkit-use-agent
 
 ## Copyable Example
@@ -65,7 +66,8 @@ Use this shape unless the repo already has a stronger established pattern:
 6. Use `step.waitForEvent` or `step.waitForSignal` for human approval and
    external callbacks.
 7. Publish durable progress with native realtime.
-8. Apply flow control at the function level for provider and tenant limits.
+8. Add sessions and scores when the agent outcome needs to be evaluated later.
+9. Apply flow control at the function level for provider and tenant limits.
 
 ## Basic AgentKit Function
 
@@ -164,6 +166,15 @@ For v4 native realtime:
 
 For AgentKit-specific UI hooks, check the installed `@inngest/agent-kit`
 version and current docs before wiring `useAgent` or `useChat`.
+
+## Agent Evals
+
+Use `inngest-agent-evals` when the user asks to score an agent, compare prompts
+or models, track user feedback, group runs by conversation/ticket, or debug
+agent quality over time. In durable agent workflows, add `meta.sessions` at the
+event that starts or connects the user flow, use direct scoring for signals
+known during the run, and use deferred scorers for product outcomes that arrive
+later.
 
 ## Flow Control and Cost
 

--- a/skills/inngest-brownfield-audit/SKILL.md
+++ b/skills/inngest-brownfield-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inngest-brownfield-audit
-description: Use when analyzing an existing TypeScript or JavaScript codebase to decide where and how to introduce Inngest. Covers repository discovery, framework and package detection, finding durability gaps in HTTP handlers, webhooks, cron jobs, queues, long-running jobs, AI agents, polling loops, and side-effect-heavy code, then producing and implementing an incremental integration plan.
+description: Use when analyzing an existing TypeScript or JavaScript codebase to decide where and how to introduce Inngest. Covers repository discovery, framework and package detection, finding durability gaps in HTTP handlers, webhooks, cron jobs, queues, long-running jobs, AI agents, Agent Evals, polling loops, eval loops, and side-effect-heavy code, then producing and implementing an incremental integration plan.
 ---
 
 # Inngest Brownfield Audit
@@ -26,7 +26,9 @@ Use this skill for requests like:
 
 If the user is starting from scratch instead of a brownfield repo, use
 `inngest-setup`, `inngest-durable-functions`, `inngest-events`,
-`inngest-steps`, and, for AI workflows, the agent patterns in this skill.
+`inngest-steps`, and, for AI workflows, the agent patterns in this skill. Use
+`inngest-agent-evals` when the request includes scoring, sessions, experiments,
+deferred scorers, Insights, or outcome-based evaluation.
 
 ## Audit Loop
 
@@ -60,8 +62,9 @@ If the user is starting from scratch instead of a brownfield repo, use
      processing, embeddings, bulk email, imports, ETL, sync jobs, polling loops,
      retries, and external API calls.
    - Search for AI agent shapes: tool loops, LLM calls, streaming tokens,
-     human approval, multi-step reasoning, vector search, eval loops, and
-     provider calls that need rate limits or retry-safe state.
+     human approval, multi-step reasoning, vector search, eval loops, scoring,
+     experiment assignment, user-feedback signals, and provider calls that need
+     rate limits or retry-safe state.
 
 4. **Classify each candidate.**
    - **P0:** user-visible loss, duplicate charge/email/action, timeout, missed
@@ -109,6 +112,7 @@ generated/vendor folders.
 | External API hits 429s | Move limits to function config | `throttle`, `rateLimit`, `concurrency` |
 | Human review can take days | Persist the wait in Inngest | `step.waitForEvent`, timeout, realtime |
 | AI agent/tool loop needs retry-safe progress | One step per tool/model boundary | `step.ai`, `step.run`, `step.sleep`, realtime |
+| AI workflow needs production evals | Attach outcome signals to durable runs | `meta.sessions`, `step.score`, `createScorer`, `defer`, `group.experiment` |
 | Existing queue only hides fragile work | Replace queue boundary gradually | Event trigger, idempotency, function-level retries |
 
 ## Integration Plan Format


### PR DESCRIPTION
## Summary

- Add `inngest-agent-evals` as a shared skill for production Agent Evals workflows.
- Cross-link durable agent and brownfield audit skills to the Agent Evals handoff.
- Update README and roadmap inventory so the shared skills repo lists Agent Evals as a first-class capability.

## Canonical docs

- https://www.inngest.com/docs/learn/agent-evals
- https://www.inngest.com/docs/features/inngest-functions/steps-workflows/scoring
- https://www.inngest.com/docs/features/inngest-functions/steps-workflows/deferred-scoring
- https://www.inngest.com/docs/features/inngest-functions/steps-workflows/step-experiments
- https://www.inngest.com/docs/features/events-triggers/sessions

## Validation

- `python3 /Users/sterlingchin/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/inngest-agent-evals`
- `cmp -s /Users/sterlingchin/inngest/inngest-codex-plugin/plugins/inngest/skills/inngest-agent-evals/SKILL.md skills/inngest-agent-evals/SKILL.md`
- `git diff --check`

Tracking: DEV-452